### PR TITLE
Skip unreadable config files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,11 +55,11 @@ jobs:
 
       matrix:
         python:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v2
       - name: Setup python${{ matrix.python }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argclass"
-version = "1.1.0"
+version = "1.1.1"
 description = "A wrapper around the standard argparse module that allows you to describe argument parsers declaratively"
 authors = ["Dmitry Orlov <me@mosquito.su>"]
 readme = "README.md"
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python",
     "Typing :: Typed",
@@ -36,7 +36,7 @@ packages = [
 "Documentation" = "https://github.com/mosquito/argclass/blob/master/README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 coveralls = ">=3.3.1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,3 +63,18 @@ def test_config_defaults(tmp_path: Path):
     parser = Parser(config_files=[config_file])
     parser.parse_args([])
     assert parser.foo == "bar"
+
+
+def test_unreadable_config(tmp_path: Path):
+    config_file = tmp_path / "config.ini"
+    with open(config_file, "w") as fp:
+        fp.write("TOP SECRET")
+
+    # Make the config file not read just writeable
+    config_file.chmod(0o200)
+
+    class Parser(argclass.Parser):
+        pass
+
+    parser = Parser(config_files=[config_file])
+    parser.parse_args([])


### PR DESCRIPTION
# v1.1.1 — drop 3.8, add 3.13, safer config loading

## Features & Fixes

* Config loading
  * read_configs() now skips paths that are missing or unreadable (os.R_OK).
  * Parser accepts strict_config: bool → passed straight through to ConfigParser.
* Python support
  * Removed: 3.8
  * Added: 3.13
  * Updated GitHub Actions matrix, Trove classifiers, python = "^3.9" in pyproject.toml.
* Tests
  * New case test_unreadable_config() covers unreadable file scenario.