### PR TITLE
Support for from __future__ import annotations

### DIFF
--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -37,8 +37,8 @@ from .types import Actions, Nargs
 from .utils import (
     _unwrap_container_type,
     deep_getattr,
-    merge_annotations,
     parse_bool,
+    resolve_annotations,
     unwrap_literal,
     unwrap_optional,
 )
@@ -89,10 +89,7 @@ class Meta(ABCMeta):
         cls = super().__new__(mcs, name, bases, attrs)
 
         # Now get annotations from the created class
-        annotations = merge_annotations(
-            getattr(cls, "__annotations__", {}),
-            *bases,
-        )
+        annotations = resolve_annotations(cls)
 
         arguments = {}
         argument_groups = {}

--- a/argclass/store.py
+++ b/argclass/store.py
@@ -12,7 +12,7 @@ from .actions import (
     TOMLConfigAction,
 )
 from .types import Actions, ConverterType, Nargs
-from .utils import merge_annotations
+from .utils import resolve_annotations
 
 
 class StoreMeta(type):
@@ -28,10 +28,7 @@ class StoreMeta(type):
         # Python 3.14+ (PEP 649) defers annotation evaluation
         cls = super().__new__(mcs, name, bases, attrs)
 
-        annotations = merge_annotations(
-            getattr(cls, "__annotations__", {}),
-            *bases,
-        )
+        annotations = resolve_annotations(cls)
         setattr(cls, "__annotations__", annotations)
         setattr(
             cls,

--- a/argclass/utils.py
+++ b/argclass/utils.py
@@ -15,6 +15,7 @@ from typing import (
     Union,
     get_args,
     get_origin,
+    get_type_hints,
 )
 
 from .exceptions import ComplexTypeError
@@ -80,6 +81,22 @@ def merge_annotations(
             result.update(getattr(cls, "__annotations__", {}))
     result.update(annotations)
     return result
+
+
+def resolve_annotations(cls: type) -> Dict[str, Any]:
+    """Resolve annotations for a class, handling stringified annotations.
+
+    Uses typing.get_type_hints() to resolve string annotations
+    (from ``from __future__ import annotations`` or PEP 649).
+    Falls back to merge_annotations() if resolution fails.
+    """
+    try:
+        return get_type_hints(cls)
+    except Exception:
+        return merge_annotations(
+            getattr(cls, "__annotations__", {}),
+            *cls.__mro__[1:],
+        )
 
 
 def parse_bool(value: str) -> bool:

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Literal, Optional
+
+import argclass
+
+
+class Color(IntEnum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+
+class TestFutureAnnotations:
+    """Test that `from __future__ import annotations` works correctly."""
+
+    def test_basic_types(self):
+        class CLI(argclass.Parser):
+            host: str = "localhost"
+            port: int = 8080
+            verbose: bool = False
+
+        parser = CLI()
+        parser.parse_args(
+            ["--host", "example.com", "--port", "9090", "--verbose"],
+        )
+        assert parser.host == "example.com"
+        assert parser.port == 9090
+        assert parser.verbose is True
+
+    def test_optional(self):
+        class CLI(argclass.Parser):
+            name: Optional[str] = None
+
+        parser = CLI()
+        parser.parse_args([])
+        assert parser.name is None
+        parser.parse_args(["--name", "test"])
+        assert parser.name == "test"
+
+    def test_literal(self):
+        class CLI(argclass.Parser):
+            mode: Literal["fast", "slow"] = "fast"
+
+        parser = CLI()
+        parser.parse_args(["--mode", "slow"])
+        assert parser.mode == "slow"
+
+    def test_list(self):
+        class CLI(argclass.Parser):
+            tags: list[str] = argclass.Argument(
+                nargs=argclass.Nargs.ONE_OR_MORE,
+            )
+
+        parser = CLI()
+        parser.parse_args(["--tags", "a", "b", "c"])
+        assert parser.tags == ["a", "b", "c"]
+
+    def test_enum(self):
+        class CLI(argclass.Parser):
+            color: Color = Color.RED
+
+        parser = CLI()
+        parser.parse_args(["--color", "GREEN"])
+        assert parser.color == Color.GREEN
+
+    def test_group(self):
+        class DB(argclass.Group):
+            host: str = "localhost"
+            port: int = 5432
+
+        class CLI(argclass.Parser):
+            db: DB = DB(title="Database")
+
+        parser = CLI()
+        parser.parse_args(
+            ["--db-host", "dbhost", "--db-port", "3306"],
+        )
+        assert parser.db.host == "dbhost"
+        assert parser.db.port == 3306
+
+    def test_subparsers(self):
+        class Serve(argclass.Parser):
+            port: int = 8080
+
+        class CLI(argclass.Parser):
+            serve = Serve()
+
+        parser = CLI()
+        parser.parse_args(["serve", "--port", "9090"])
+
+    def test_secret(self):
+        class CLI(argclass.Parser):
+            api_key: str = argclass.Secret()
+
+        parser = CLI()
+        parser.parse_args(["--api-key", "my-secret"])
+        assert parser.api_key == "my-secret"


### PR DESCRIPTION
This pull request improves support for Python's `from __future__ import annotations` (PEP 563/649) in the `argclass` library by introducing a new utility function to robustly resolve type annotations, even when they are stringified. The changes ensure that type hints are correctly interpreted in modern Python versions and add comprehensive tests to verify this behavior.

**Enhanced annotation resolution:**

* Added a new `resolve_annotations` function in `argclass/utils.py` that uses `typing.get_type_hints()` to resolve stringified annotations, falling back to the legacy `merge_annotations` if needed. This function is now used in both `argclass/parser.py` and `argclass/store.py` to retrieve class annotations, replacing direct usage of `merge_annotations`. [[1]](diffhunk://#diff-cd8a6138e4bbe0d5c40e2bc0562528150d8ae91469c406820a5c86893f2b5572R86-R101) [[2]](diffhunk://#diff-9a62e2936b43864e76e5912a4ca4b14b56d5fa188e1c16f573666ef5428db934L40-R41) [[3]](diffhunk://#diff-9a62e2936b43864e76e5912a4ca4b14b56d5fa188e1c16f573666ef5428db934L92-R92) [[4]](diffhunk://#diff-9363e082bf483d224ffae5163dff7c13e666c05ec30b651f42e1279510d6043dL15-R15) [[5]](diffhunk://#diff-9363e082bf483d224ffae5163dff7c13e666c05ec30b651f42e1279510d6043dL31-R31) [[6]](diffhunk://#diff-cd8a6138e4bbe0d5c40e2bc0562528150d8ae91469c406820a5c86893f2b5572R18)

**Testing for future annotations:**

* Added a new test file `tests/test_future_annotations.py` with comprehensive test cases to ensure `argclass` works correctly when `from __future__ import annotations` is enabled, covering basic types, optionals, literals, lists, enums, groups, subparsers, and secrets.