### PR TITLE
Support for extra kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,43 @@ class Parser(argclass.Parser):
 # repr() returns '******', str() returns actual value
 ```
 
+### Argparse Passthrough
+
+`Argument()` forwards any extra keyword arguments to
+`argparse.add_argument()`, so argparse-specific options like `version=` work
+out of the box:
+
+<!--- name: test_version_example --->
+```python
+import argclass
+
+class CLI(argclass.Parser):
+    version = argclass.Argument(
+        "-V", "--version",
+        action=argclass.Actions.VERSION,
+        version="myapp/1.2.3",
+    )
+
+try:
+    CLI().parse_args(["--version"])
+except SystemExit as exc:
+    assert exc.code == 0
+```
+
+### Interactive Examples
+
+Run `python -m argclass` to explore all features interactively.
+Each subcommand prints its own source code and demonstrates a different feature:
+
+```bash
+python -m argclass basic          # str, int, float, bool, Optional
+python -m argclass types          # Literal, list, Enum, frozenset
+python -m argclass groups         # argument groups with prefixes
+python -m argclass secrets        # Secret and SecretString masking
+python -m argclass env            # environment variable integration
+python -m argclass subcommands    # nested subcommands with __call__
+```
+
 ## Documentation
 
 Full documentation at **[docs.argclass.com](https://docs.argclass.com)**:

--- a/argclass/__main__.py
+++ b/argclass/__main__.py
@@ -1,36 +1,448 @@
 import argparse
+import inspect
+import os
 import sys
+import textwrap
+from enum import Enum
 from pathlib import Path
+from typing import Literal, Optional
 
 import argclass
 
 
-class GreetCommand(argclass.Parser):
-    user: str = argclass.Argument("user", help="User to greet")
+def print_source(*classes_or_instances: object) -> None:
+    """Print the source code of classes or instances."""
+    print("### Source code ###\n")
+    for obj in classes_or_instances:
+        cls = obj if isinstance(obj, type) else type(obj)
+        print(textwrap.dedent(inspect.getsource(cls)))
+    print("###################")
+    print()
+
+
+DESCRIPTION = """\
+argclass — declarative CLI parser built on top of argparse.
+
+Type hints become CLI arguments automatically:
+  str → string, int → integer, bool → flag,
+  Optional[T] → optional, list[T] → multi-value,
+  Literal[...] → choices, Enum → choices.
+
+Priority: defaults < config files < env vars < CLI args.
+
+Minimal example:
+
+  class CLI(argclass.Parser):
+      host: str = "localhost"      # --host
+      port: int = 8080             # --port
+      verbose: bool = False        # --verbose (flag)
+
+  parser = CLI()
+  parser.parse_args()
+
+Run subcommands below to explore each feature interactively:
+"""
+
+EPILOG = """\
+Value priority (lowest to highest):
+  1. Class defaults
+  2. Config files (INI/JSON/TOML)
+  3. Environment variables
+  4. CLI arguments
+
+Examples:
+  %(prog)s basic --name World --count 3 --debug
+  %(prog)s types --mode fast --tags a b c --color green
+  %(prog)s groups --server-host 0.0.0.0 --db-port 3306
+  %(prog)s secrets --api-key my-secret
+  DEMO_HOST=example.com %(prog)s env
+  %(prog)s subcommands hello --user Alice
+"""
+
+
+# -- Helper types -------------------------------------------------
+
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+# -- Groups -------------------------------------------------------
+
+
+class ServerGroup(argclass.Group):
+    host: str = "localhost"
+    port: int = 8080
+
+
+class DatabaseGroup(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+    name: str = "mydb"
+
+
+# -- Subcommand: basic -------------------------------------------
+
+
+class BasicDemo(argclass.Parser):
+    """Demonstrates basic type annotations.
+
+    Python type hints map directly to argparse argument types:
+
+      class CLI(argclass.Parser):
+          name: str = "world"          # --name (string)
+          count: int = 1               # --count (integer)
+          ratio: float = 0.5           # --ratio (float)
+          debug: bool = False          # --debug (flag)
+          nickname: Optional[str]      # --nickname (optional)
+
+    Try: basic --name Test --count 3 --ratio 0.7 --debug
+    """
+
+    name: str = argclass.Argument(
+        default="world",
+        help="A string argument",
+    )
+    count: int = argclass.Argument(
+        default=1,
+        help="An integer argument",
+    )
+    ratio: float = argclass.Argument(
+        default=0.5,
+        help="A float argument",
+    )
+    debug: bool = False
+    nickname: Optional[str] = argclass.Argument(
+        default=None,
+        help="Optional string (not required)",
+    )
 
     def __call__(self) -> int:
-        print(f"Hello, {self.user}!")
+        print_source(self)
+        print("== Basic Type Annotations ==\n")
+        print(f"  name     = {self.name!r:20s} (str)")
+        print(f"  count    = {self.count!r:20s} (int)")
+        print(f"  ratio    = {self.ratio!r:20s} (float)")
+        print(f"  debug    = {self.debug!r:20s} (bool flag)")
+        print(f"  nickname = {self.nickname!r:20s} (Optional[str])")
+        print()
+        print("How it works:")
+        print("  - str/int/float → argparse uses the type directly")
+        print("  - bool with False default → --debug is store_true")
+        print("  - Optional[str] → argument is not required")
         return 0
 
 
-class Parser(argclass.Parser):
+# -- Subcommand: types -------------------------------------------
+
+
+class TypesDemo(argclass.Parser):
+    """Demonstrates advanced types: Literal, list, Enum, frozenset.
+
+      class CLI(argclass.Parser):
+          mode: Literal["fast", "slow", "auto"] = "auto"
+          tags: list[str] = []       # --tags a b c
+          color: Color = Color.RED   # --color {red,green,blue}
+          unique: frozenset[int] = argclass.Argument(
+              type=int, nargs="+", converter=frozenset,
+          )
+
+    Try: types --mode fast --tags a b c --color green \\
+               --unique 1 2 3 2 1
+    """
+
+    mode: Literal["fast", "slow", "auto"] = argclass.Argument(
+        default="auto",
+        help="Literal type becomes choices",
+    )
+    tags: list[str] = argclass.Argument(
+        nargs=argclass.Nargs.ZERO_OR_MORE,
+        default=[],
+        help="List of strings (nargs=*)",
+    )
+    color: Color = argclass.Argument(
+        default=Color.RED,
+        help="Enum type becomes choices",
+    )
+    unique: frozenset = argclass.Argument(  # type: ignore[type-arg]
+        type=int,
+        nargs=argclass.Nargs.ONE_OR_MORE,
+        converter=frozenset,
+        default=frozenset(),
+        help="frozenset deduplicates values",
+    )
+
+    def __call__(self) -> int:
+        print_source(Color, self)
+        print("== Advanced Types ==\n")
+        print(f"  mode   = {self.mode!r}")
+        print("    Literal['fast','slow','auto'] → choices")
+        print(f"  tags   = {self.tags!r}")
+        print("    list[str] with nargs=* → multiple values")
+        print(f"  color  = {self.color!r}")
+        print("    Enum → choices from enum values")
+        print(f"  unique = {self.unique!r}")
+        print("    frozenset + converter → deduplicated")
+        return 0
+
+
+# -- Subcommand: groups ------------------------------------------
+
+
+class GroupsDemo(argclass.Parser):
+    """Demonstrates argument groups with prefixes.
+
+    Groups organize related arguments and add prefixes
+    to avoid name collisions:
+
+      class ServerGroup(argclass.Group):
+          host: str = "localhost"
+          port: int = 8080
+
+      class DatabaseGroup(argclass.Group):
+          host: str = "localhost"
+          port: int = 5432
+
+      class CLI(argclass.Parser):
+          server = ServerGroup(title="Server options")
+          db = DatabaseGroup(
+              title="Database options", prefix="db",
+          )
+
+    Both groups have 'host' and 'port', but CLI flags
+    are --server-host/--server-port vs --db-host/--db-port.
+
+    Try: groups --server-host 0.0.0.0 --server-port 9090 \\
+               --db-host db.local --db-port 3306 --db-name app
+    """
+
+    server: ServerGroup = ServerGroup(title="Server options")
+    db: DatabaseGroup = DatabaseGroup(
+        title="Database options",
+        prefix="db",
+    )
+
+    def __call__(self) -> int:
+        print_source(self.server, self.db, self)
+        print("== Argument Groups ==\n")
+        print("  Server group (prefix='server'):")
+        print(f"    --server-host = {self.server.host!r}")
+        print(f"    --server-port = {self.server.port!r}")
+        print()
+        print("  Database group (prefix='db'):")
+        print(f"    --db-host     = {self.db.host!r}")
+        print(f"    --db-port     = {self.db.port!r}")
+        print(f"    --db-name     = {self.db.name!r}")
+        print()
+        print("How it works:")
+        print("  - Group name or explicit prefix= avoids")
+        print("    collisions when fields have the same name")
+        print("  - Each group gets its own section in --help")
+        return 0
+
+
+# -- Subcommand: secrets -----------------------------------------
+
+
+class SecretsDemo(argclass.Parser):
+    """Demonstrates Secret arguments and SecretString masking.
+
+      class CLI(argclass.Parser):
+          api_key: str = argclass.Secret(
+              env_var="API_KEY",
+              help="Masked in repr/logs",
+          )
+          password: str = argclass.Secret()
+          username: str = "admin"   # not a secret
+
+    Secret values are wrapped in SecretString:
+      - repr(value) → '******' (safe for logs)
+      - str(value)  → actual value (when you need it)
+
+    Try: secrets --api-key sk-12345 --password hunter2
+    Also: API_KEY=from-env secrets
+    """
+
+    api_key: str = argclass.Secret(
+        default="demo-key",
+        env_var="DEMO_API_KEY",
+        help="API key (masked in repr)",
+    )
+    password: str = argclass.Secret(
+        default="s3cret",
+        help="Password (masked in repr)",
+    )
+    username: str = argclass.Argument(
+        default="admin",
+        help="Username (not a secret, shown normally)",
+    )
+
+    def __call__(self) -> int:
+        print_source(self)
+        print("== Secrets & SecretString ==\n")
+        print(f"  api_key  repr = {self.api_key!r}")
+        print(f"  api_key  str  = {self.api_key!s}")
+        print(f"  password repr = {self.password!r}")
+        print(f"  password str  = {self.password!s}")
+        print(f"  username repr = {self.username!r}")
+        print()
+        print("How it works:")
+        print("  - Secret() wraps the value in SecretString")
+        print("  - repr() shows '******' (safe for logging)")
+        print("  - str() returns the actual value")
+        print("  - parser.sanitize_env() clears env vars")
+        print("    after parsing (prevents leaking to child")
+        print("    processes)")
+        return 0
+
+
+# -- Subcommand: env ---------------------------------------------
+
+
+class EnvDemo(argclass.Parser):
+    """Demonstrates environment variable integration.
+
+    Per-argument env vars:
+
+      class CLI(argclass.Parser):
+          host: str = argclass.Argument(
+              default="localhost", env_var="APP_HOST",
+          )
+
+    Auto-prefix for all arguments:
+
+      parser = CLI(auto_env_var_prefix="APP_")
+      # --host reads from APP_HOST automatically
+
+    Priority: default < env var < CLI argument.
+
+    Try: DEMO_HOST=from-env DEMO_PORT=9999 env
+    Try: DEMO_HOST=from-env env --host from-cli
+    """
+
+    host: str = argclass.Argument(
+        default="localhost",
+        env_var="DEMO_HOST",
+        help="Server host [env: DEMO_HOST]",
+    )
+    port: int = argclass.Argument(
+        default=8080,
+        env_var="DEMO_PORT",
+        help="Server port [env: DEMO_PORT]",
+    )
+
+    def __call__(self) -> int:
+        print_source(self)
+        print("== Environment Variables ==\n")
+        print(f"  host = {self.host!r}")
+        print(f"    env DEMO_HOST = {os.environ.get('DEMO_HOST')!r}")
+        print(f"  port = {self.port!r}")
+        print(f"    env DEMO_PORT = {os.environ.get('DEMO_PORT')!r}")
+        print()
+        print("How it works:")
+        print("  - env_var='NAME' on an argument reads from")
+        print("    that environment variable")
+        print("  - auto_env_var_prefix='APP_' on Parser()")
+        print("    generates env var names for all arguments")
+        print("    automatically (e.g. --host → APP_HOST)")
+        print("  - CLI args always override env vars")
+        print("  - parser.sanitize_env() clears them after")
+        return 0
+
+
+# -- Subcommand: subcommands (with nesting) ----------------------
+
+
+class HelloCommand(argclass.Parser):
+    """Says hello to a user."""
+
+    user: str = argclass.Argument(
+        default="World",
+        help="Who to greet",
+    )
+    greeting: str = argclass.Argument(
+        default="Hello",
+        help="Greeting word",
+    )
+
+    def __call__(self) -> int:
+        print_source(self)
+        print(f"{self.greeting}, {self.user}!")
+        return 0
+
+
+class InfoCommand(argclass.Parser):
+    """Shows system information."""
+
     verbose: bool = False
-    secret_key: str = argclass.Secret(help="Secret API key")
-    greet = GreetCommand()
 
     def __call__(self) -> int:
-        self.print_help()
+        print_source(self)
+        print(f"Python:   {sys.version}")
+        print(f"argclass: {argclass.__file__}")
+        if self.verbose:
+            print(f"Platform: {sys.platform}")
+            print(f"Prefix:   {sys.prefix}")
         return 0
+
+
+class SubcommandDemo(argclass.Parser):
+    """Demonstrates subcommands and __call__ dispatch.
+
+    Subcommands are Parser subclasses assigned as attributes.
+    The default __call__ auto-dispatches to the selected
+    subcommand. Override it for custom logic.
+
+    Try: subcommands hello --user Alice
+    Try: subcommands info --verbose
+    """
+
+    hello = HelloCommand()
+    info = InfoCommand()
+
+    def __call__(self) -> int:
+        # Find a nested subparser (skip self in the chain)
+        for sp in self.current_subparsers:
+            if sp is not self:
+                return sp()  # type: ignore[return-value]
+        print_source(self.hello, self.info, self)
+        self.print_help()
+        return 1
+
+
+# -- Top-level parser --------------------------------------------
+
+
+class DemoParser(argclass.Parser):
+    verbose: bool = False
+    log_level: int = argclass.LogLevel
+
+    basic = BasicDemo()
+    types = TypesDemo()
+    groups = GroupsDemo()
+    secrets = SecretsDemo()
+    env = EnvDemo()
+    subcommands = SubcommandDemo()
+
+    def __call__(self) -> int:
+        result = super().__call__()
+        if result is None:
+            self.print_help()
+            return 0
+        return result
+
+
+# -- Entry point -------------------------------------------------
 
 
 def main() -> None:
-    parser = Parser(
+    parser = DemoParser(
         prog=f"{Path(sys.executable).name} -m argclass",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=(
-            "This code produces this help:\n\n```"
-            f"python\n{open(__file__).read().strip()}\n```"
-        ),
+        description=DESCRIPTION,
+        epilog=EPILOG,
     )
     parser.parse_args()
     parser.sanitize_env()

--- a/argclass/factory.py
+++ b/argclass/factory.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from pathlib import Path
+from types import MappingProxyType
 from typing import (
     Any,
     Callable,
@@ -46,12 +47,17 @@ def ArgumentSingle(
     metavar: Optional[MetavarType] = None,
     required: Optional[bool] = None,
     secret: bool = False,
+    **extra_kwargs: Any,
 ) -> T:
     """
     Create a single-value argument with precise typing.
 
     Use this when you need exact type inference for a single value.
     The `type` parameter is required and determines the return type.
+
+    Any extra keyword arguments are passed through to
+    ``argparse.ArgumentParser.add_argument`` (e.g., ``version='1.0'``
+    for ``action=Actions.VERSION``).
 
     Example:
         class Parser(argclass.Parser):
@@ -69,6 +75,7 @@ def ArgumentSingle(
             default=default,
             secret=secret,
             env_var=env_var,
+            extra_kwargs=MappingProxyType(dict(extra_kwargs or {})),
             help=help,
             metavar=metavar,
             nargs=None,
@@ -93,12 +100,16 @@ def ArgumentSequence(
     metavar: Optional[MetavarType] = None,
     required: Optional[bool] = None,
     secret: bool = False,
+    **extra_kwargs: Any,
 ) -> List[T]:
     """
     Create a multi-value argument with precise typing.
 
     Use this when you need exact type inference for a list of values.
     The ``type`` parameter is required and determines the element type.
+
+    Any extra keyword arguments are passed through to
+    ``argparse.ArgumentParser.add_argument``.
 
     Args:
         nargs: Number of values. Defaults to "+" (one or more).
@@ -123,6 +134,7 @@ def ArgumentSequence(
             default=default,
             secret=secret,
             env_var=env_var,
+            extra_kwargs=MappingProxyType(dict(extra_kwargs or {})),
             help=help,
             metavar=metavar,
             nargs=nargs,
@@ -151,6 +163,7 @@ def Argument(
     metavar: Optional[MetavarType] = ...,
     required: Optional[bool] = ...,
     secret: bool = ...,
+    **extra_kwargs: Any,
 ) -> R: ...
 
 
@@ -170,6 +183,7 @@ def Argument(
     metavar: Optional[MetavarType] = ...,
     required: Optional[bool] = ...,
     secret: bool = ...,
+    **extra_kwargs: Any,
 ) -> T: ...
 
 
@@ -189,6 +203,7 @@ def Argument(
     metavar: Optional[MetavarType] = ...,
     required: Optional[bool] = ...,
     secret: bool = ...,
+    **extra_kwargs: Any,
 ) -> T: ...
 
 
@@ -208,6 +223,7 @@ def Argument(
     metavar: Optional[MetavarType] = ...,
     required: Optional[bool] = ...,
     secret: bool = ...,
+    **extra_kwargs: Any,
 ) -> List[T]: ...
 
 
@@ -227,6 +243,7 @@ def Argument(
     metavar: Optional[MetavarType] = ...,
     required: Optional[bool] = ...,
     secret: bool = ...,
+    **extra_kwargs: Any,
 ) -> List[T]: ...
 
 
@@ -246,6 +263,7 @@ def Argument(
     nargs: None = ...,
     required: Optional[bool] = ...,
     secret: bool = ...,
+    **extra_kwargs: Any,
 ) -> T: ...
 
 
@@ -265,6 +283,7 @@ def Argument(
     nargs: None = ...,
     required: Optional[bool] = ...,
     secret: bool = ...,
+    **extra_kwargs: Any,
 ) -> T: ...
 
 
@@ -284,6 +303,7 @@ def Argument(
     required: Optional[bool] = ...,
     secret: bool = ...,
     type: Optional[ConverterType] = ...,
+    **extra_kwargs: Any,
 ) -> T: ...
 
 
@@ -303,6 +323,7 @@ def Argument(
     required: Optional[bool] = ...,
     secret: bool = ...,
     type: Optional[ConverterType] = ...,
+    **extra_kwargs: Any,
 ) -> Any: ...
 
 
@@ -321,6 +342,7 @@ def Argument(
     required: Optional[bool] = None,
     secret: bool = False,
     type: Optional[ConverterType] = None,
+    **extra_kwargs: Any,
 ) -> Any:
     """
     Create a typed argument for a Parser or Group class.
@@ -390,6 +412,7 @@ def Argument(
                 metavar=metavar,
                 required=required,
                 secret=secret,
+                **extra_kwargs,
             )
         elif nargs == "?" or nargs == Nargs.ZERO_OR_ONE:
             # nargs="?" needs special handling - creates TypedArgument directly
@@ -401,6 +424,7 @@ def Argument(
                 converter=converter,
                 default=default,
                 env_var=env_var,
+                extra_kwargs=MappingProxyType(dict(extra_kwargs or {})),
                 help=help,
                 metavar=metavar,
                 nargs=nargs,
@@ -422,6 +446,7 @@ def Argument(
                 metavar=metavar,
                 required=required,
                 secret=secret,
+                **extra_kwargs,
             )
 
     # Fallback for untyped arguments
@@ -434,6 +459,7 @@ def Argument(
         default=default,
         secret=secret,
         env_var=env_var,
+        extra_kwargs=MappingProxyType(dict(extra_kwargs or {})),
         help=help,
         metavar=metavar,
         nargs=nargs,

--- a/argclass/secret.py
+++ b/argclass/secret.py
@@ -21,13 +21,14 @@ class SecretString(str):
     Examples:
 
     >>> import logging
+    >>> import sys
     >>> from argclass import SecretString
-    >>> logging.basicConfig(level=logging.INFO)
+    >>> logging.basicConfig(level=logging.INFO, stream=sys.stdout, force=True)
     >>> s = SecretString("my-secret-password")
     >>> logging.info(s)          # __str__ will be called from logging
-    INFO:root:'******'
+    INFO:root:******
     >>> logging.info(f"s=%s", s) # __str__ will be called from logging too
-    INFO:root:s='******'
+    INFO:root:s=******
     >>> logging.info(f"{s!r}")   # repr is safe
     INFO:root:'******'
     >>> logging.info(f"{s}")     # the password will be compromised

--- a/argclass/store.py
+++ b/argclass/store.py
@@ -3,7 +3,18 @@
 import collections
 from argparse import Action
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, Optional, Tuple, Type, Union
+from types import MappingProxyType
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from .actions import (
     ConfigAction,
@@ -114,19 +125,28 @@ class ArgumentBase(Store):
         action = self.action
         kwargs = self.as_dict()
 
-        if action in (Actions.STORE_TRUE, Actions.STORE_FALSE, Actions.COUNT):
+        if action in (
+            Actions.STORE_TRUE,
+            Actions.STORE_FALSE,
+            Actions.COUNT,
+            Actions.HELP,
+            Actions.VERSION,
+        ):
             kwargs.pop("type", None)
 
         if isinstance(action, Actions):
             action = action.value
 
+        extra_kwargs = kwargs.pop("extra_kwargs")
         kwargs.pop("aliases", None)
         kwargs.pop("converter", None)
         kwargs.pop("env_var", None)
         kwargs.pop("secret", None)
         kwargs.update(action=action, nargs=nargs)
 
-        return {k: v for k, v in kwargs.items() if v is not None}
+        result = {k: v for k, v in kwargs.items() if v is not None}
+        result.update(extra_kwargs)
+        return result
 
 
 class TypedArgument(ArgumentBase):
@@ -140,6 +160,7 @@ class TypedArgument(ArgumentBase):
     default: Optional[Any] = None
     secret: bool = False
     env_var: Optional[str] = None
+    extra_kwargs: Mapping[str, Any] = MappingProxyType({})
     help: Optional[str] = None
     metavar: Optional[str] = None
     nargs: Optional[Union[int, Nargs]] = None

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -561,3 +561,38 @@ parser.parse_args(["--date", "2024-01-15", "--output", "/tmp/output"])
 assert parser.date == datetime(2024, 1, 15)
 assert parser.output == Path("/tmp/output")
 ```
+
+## Argparse Passthrough Kwargs
+
+`Argument()`, `ArgumentSingle()`, and `ArgumentSequence()` accept arbitrary
+extra keyword arguments via `**kwargs` and forward them as-is to
+`argparse.ArgumentParser.add_argument()`. This lets you use argparse features
+that argclass doesn't model explicitly — most commonly the `version` parameter
+for `action=Actions.VERSION`.
+
+<!--- name: test_args_version_action --->
+```python
+import argclass
+
+class CLI(argclass.Parser):
+    version = argclass.Argument(
+        "-V", "--version",
+        action=argclass.Actions.VERSION,
+        version="myapp/1.2.3",
+    )
+
+# argparse's version action prints the version and exits the process
+try:
+    CLI().parse_args(["--version"])
+except SystemExit as exc:
+    assert exc.code == 0
+```
+
+The same passthrough works for `Actions.HELP` and any custom argparse `Action`
+subclass that takes constructor kwargs beyond argclass's built-in set. argclass
+automatically strips the `type` parameter for `VERSION`, `HELP`, `STORE_TRUE`,
+`STORE_FALSE`, and `COUNT` actions, since argparse rejects `type=` for them.
+
+Extra kwargs are stored as an immutable `MappingProxyType` on the resulting
+argument and merged into the kwargs passed to `add_argument()` at parser
+construction time.

--- a/docs/index.md
+++ b/docs/index.md
@@ -317,55 +317,19 @@ After installation, verify it works:
 
 ```console
 $ python -m argclass --help
-usage: python -m argclass [-h] [--verbose] [--secret-key SECRET_KEY] {greet} ...
+```
 
-This code produces this help:
+This launches an interactive demo with subcommands that demonstrate
+each argclass feature. Every subcommand prints its own source code,
+so you can see both the code and the result:
 
-import argparse
-import sys
-from pathlib import Path
-
-import argclass
-
-class GreetCommand(argclass.Parser):
-    user: str = argclass.Argument("user", help="User to greet")
-
-    def __call__(self) -> int:
-        print(f"Hello, {self.user}!")
-        return 0
-
-class Parser(argclass.Parser):
-    verbose: bool = False
-    secret_key: str = argclass.Secret(help="Secret API key")
-    greet = GreetCommand()
-
-def main() -> None:
-    parser = Parser(
-        prog=f"{Path(sys.executable).name} -m argclass",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=(
-            "This code produces this help:\n\n```"
-            f"python\n{open(__file__).read().strip()}\n```"
-        ),
-    )
-    parser.parse_args()
-    parser.sanitize_env()
-    exit(parser())
-
-if __name__ == "__main__":
-    main()
-
-positional arguments:
-{greet}
-
-options:
--h, --help            show this help message and exit
---verbose             (default: False)
---secret-key SECRET_KEY
-Secret API key
-
-$ python -m argclass greet Guido
-Hello, Guido!
+```console
+$ python -m argclass basic --name World --count 3 --debug
+$ python -m argclass types --mode fast --tags a b c --color green
+$ python -m argclass groups --server-host 0.0.0.0 --db-port 3306
+$ python -m argclass secrets --api-key my-secret
+$ DEMO_HOST=example.com python -m argclass env
+$ python -m argclass subcommands hello --user Alice
 ```
 
 ## Quick Examples

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,6 +6,20 @@ argclass wraps Python's standard `argparse` module, letting you describe argumen
 
 Key API classes: `Parser` (main entry point), `Argument`, `Group`, `Secret`, `INIConfig`, `JSONConfig`, `TOMLConfig`, `LogLevel`.
 
+## Interactive Examples
+
+Run `python -m argclass` to explore features interactively. Each subcommand demonstrates a different feature and prints its own source code:
+
+```bash
+python -m argclass                # overview and help
+python -m argclass basic          # str, int, float, bool, Optional
+python -m argclass types          # Literal, list, Enum, frozenset
+python -m argclass groups         # argument groups with prefixes
+python -m argclass secrets        # Secret and SecretString masking
+python -m argclass env            # environment variable integration
+python -m argclass subcommands    # nested subcommands with __call__
+```
+
 ## Quick Examples
 
 ### Minimal parser
@@ -98,7 +112,30 @@ class CLI(argclass.Parser):
     )
 ```
 
-## Docs
+### Argparse passthrough kwargs
+
+`Argument()`, `ArgumentSingle()`, and `ArgumentSequence()` accept arbitrary `**kwargs` and forward them verbatim to `argparse.ArgumentParser.add_argument()`. This unlocks argparse-specific options that argclass does not model explicitly — most notably the `version=` parameter for `action=Actions.VERSION`:
+
+```python
+import argclass
+
+class CLI(argclass.Parser):
+    version = argclass.Argument(
+        "-V", "--version",
+        action=argclass.Actions.VERSION,
+        version="myapp/1.2.3",
+    )
+
+# argparse's version action prints the version and exits
+try:
+    CLI().parse_args(["--version"])
+except SystemExit:
+    pass
+```
+
+argclass automatically strips `type=` for `VERSION`, `HELP`, `STORE_TRUE`, `STORE_FALSE`, and `COUNT` actions (argparse rejects it). Extra kwargs are frozen as an immutable `MappingProxyType` and merged into the dict passed to `add_argument()`.
+
+## Docs markdown files splitted by topic for easier navigation and LLM processing:
 
 - [Quick Start](https://docs.argclass.com/_sources/quickstart.md.txt): 5-minute overview of essential concepts
 - [Tutorial](https://docs.argclass.com/_sources/tutorial.md.txt): 30-minute guide building a complete CLI application

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1902,18 +1902,18 @@ class TestMainModule:
 
     def test_main_function_exists(self):
         """Test that main function can be imported."""
-        from argclass.__main__ import main, Parser, GreetCommand
+        from argclass.__main__ import main, DemoParser, HelloCommand
 
         assert callable(main)
-        assert issubclass(Parser, argclass.Parser)
-        assert issubclass(GreetCommand, argclass.Parser)
+        assert issubclass(DemoParser, argclass.Parser)
+        assert issubclass(HelloCommand, argclass.Parser)
 
-    def test_greet_command(self, capsys):
-        """Test GreetCommand __call__ method."""
-        from argclass.__main__ import GreetCommand
+    def test_hello_command(self, capsys):
+        """Test HelloCommand __call__ method."""
+        from argclass.__main__ import HelloCommand
 
-        cmd = GreetCommand()
-        cmd.parse_args(["World"])
+        cmd = HelloCommand()
+        cmd.parse_args(["--user", "World"])
 
         result = cmd()
         assert result == 0
@@ -1923,9 +1923,9 @@ class TestMainModule:
 
     def test_main_with_help(self):
         """Test main module with --help exits."""
-        from argclass.__main__ import Parser
+        from argclass.__main__ import DemoParser
 
-        parser = Parser(prog="test-argclass")
+        parser = DemoParser(prog="test-argclass")
 
         with pytest.raises(SystemExit) as exc_info:
             parser.parse_args(["--help"])
@@ -1937,8 +1937,11 @@ class TestMainModule:
         from argclass import __main__
         import sys
 
-        # Mock sys.argv with greet subcommand
-        monkeypatch.setattr(sys, "argv", ["argclass", "greet", "Test"])
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["argclass", "subcommands", "hello", "--user", "Test"],
+        )
 
         with pytest.raises(SystemExit) as exc_info:
             __main__.main()
@@ -1956,6 +1959,138 @@ class TestMainModule:
             runpy.run_module("argclass", run_name="__main__")
 
         assert exc_info.value.code == 0
+
+    def test_basic_demo_call(self, capsys):
+        from argclass.__main__ import BasicDemo
+
+        cmd = BasicDemo()
+        cmd.parse_args(["--name", "Test", "--count", "3", "--debug"])
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Basic Type Annotations" in out
+        assert "Test" in out
+
+    def test_types_demo_call(self, capsys):
+        from argclass.__main__ import TypesDemo
+
+        cmd = TypesDemo()
+        cmd.parse_args(
+            [
+                "--mode",
+                "fast",
+                "--tags",
+                "a",
+                "b",
+                "--color",
+                "green",
+                "--unique",
+                "1",
+                "2",
+                "1",
+            ],
+        )
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Advanced Types" in out
+        assert "fast" in out
+
+    def test_groups_demo_call(self, capsys):
+        from argclass.__main__ import GroupsDemo
+
+        cmd = GroupsDemo()
+        cmd.parse_args(
+            ["--server-host", "0.0.0.0", "--db-port", "3306"],
+        )
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Argument Groups" in out
+        assert "0.0.0.0" in out
+
+    def test_secrets_demo_call(self, capsys):
+        from argclass.__main__ import SecretsDemo
+
+        cmd = SecretsDemo()
+        cmd.parse_args(["--api-key", "sk-12345", "--password", "hunter2"])
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Secrets" in out
+        assert "******" in out
+        assert "sk-12345" in out
+
+    def test_env_demo_call(self, capsys, monkeypatch):
+        from argclass.__main__ import EnvDemo
+
+        monkeypatch.setenv("DEMO_HOST", "example.com")
+        cmd = EnvDemo()
+        cmd.parse_args([])
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Environment Variables" in out
+        assert "example.com" in out
+
+    def test_info_command_call_verbose(self, capsys):
+        from argclass.__main__ import InfoCommand
+
+        cmd = InfoCommand()
+        cmd.parse_args(["--verbose"])
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Python:" in out
+        assert "Platform:" in out
+
+    def test_info_command_call_non_verbose(self, capsys):
+        import sys
+        from argclass.__main__ import InfoCommand
+
+        cmd = InfoCommand()
+        cmd.parse_args([])
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Python:" in out
+        # Verbose-only line with actual sys.prefix path is absent
+        assert f"Prefix:   {sys.prefix}" not in out
+
+    def test_subcommand_demo_help_dispatch(self, capsys):
+        """SubcommandDemo with no nested subparser prints help and returns 1."""
+        from argclass.__main__ import SubcommandDemo
+
+        cmd = SubcommandDemo()
+        cmd.parse_args([])
+        assert cmd() == 1
+        out = capsys.readouterr().out
+        assert out  # printed help
+
+    def test_subcommand_demo_dispatches_to_hello(self, capsys):
+        """SubcommandDemo with hello subparser dispatches to HelloCommand."""
+        from argclass.__main__ import SubcommandDemo
+
+        cmd = SubcommandDemo()
+        cmd.parse_args(["hello", "--user", "Alice"])
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Hello, Alice!" in out
+
+    def test_subcommand_demo_skips_self_in_chain(self, capsys):
+        """The 'sp is not self' guard skips self when it appears in chain."""
+        from argclass.__main__ import SubcommandDemo
+
+        cmd = SubcommandDemo()
+        cmd.parse_args(["hello", "--user", "Bob"])
+        # Inject self at the front of the chain to exercise the skip branch
+        cmd.current_subparsers = (cmd,) + cmd.current_subparsers
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Hello, Bob!" in out
+
+    def test_demo_parser_no_subcommand_prints_help(self, capsys):
+        """Top-level DemoParser with no subcommand prints help and returns 0."""
+        from argclass.__main__ import DemoParser
+
+        parser = DemoParser(prog="test-argclass")
+        parser.parse_args([])
+        assert parser() == 0
+        out = capsys.readouterr().out
+        assert "usage" in out.lower()
 
 
 class TestStoreRequiredArgument:
@@ -2160,6 +2295,96 @@ class TestTypedArgumentGetKwargs:
         kwargs = arg.get_kwargs()
 
         assert kwargs["action"] == "store_true"
+        assert "type" not in kwargs
+
+
+class TestArgumentExtraKwargs:
+    """Argument() must pass unknown kwargs through to argparse.add_argument."""
+
+    def test_version_action_passes_version_kwarg(self, capsys):
+        class CLI(argclass.Parser):
+            version = argclass.Argument(
+                "-V",
+                "--version",
+                action=argclass.Actions.VERSION,
+                version="myapp/1.2.3",
+            )
+
+        parser = CLI()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--version"])
+
+        captured = capsys.readouterr()
+        assert "myapp/1.2.3" in (captured.out + captured.err)
+
+    def test_extra_kwargs_stored_on_fallback_path(self):
+        """No type, no nargs -> fallback TypedArgument path."""
+        arg = argclass.Argument(
+            "--foo",
+            action=argclass.Actions.VERSION,
+            version="x/1",
+        )
+        assert arg.extra_kwargs == {"version": "x/1"}
+        kwargs = arg.get_kwargs()
+        assert kwargs["version"] == "x/1"
+        assert kwargs["action"] == "version"
+        assert "type" not in kwargs
+
+    def test_extra_kwargs_on_argument_single_path(self):
+        """type + no nargs -> ArgumentSingle dispatch path."""
+        from argclass.store import TypedArgument
+
+        arg = argclass.Argument("--foo", type=int, my_extra="single")
+        assert isinstance(arg, TypedArgument)
+        assert arg.extra_kwargs == {"my_extra": "single"}
+
+    def test_extra_kwargs_on_argument_sequence_path(self):
+        """type + nargs="+" -> ArgumentSequence dispatch path."""
+        from argclass.store import TypedArgument
+
+        arg = argclass.Argument(
+            "--foo",
+            type=int,
+            nargs="+",
+            my_extra="seq",
+        )
+        assert isinstance(arg, TypedArgument)
+        assert arg.extra_kwargs == {"my_extra": "seq"}
+
+    def test_extra_kwargs_on_nargs_optional_path(self):
+        """type + nargs="?" -> direct TypedArgument path."""
+        from argclass.store import TypedArgument
+
+        arg = argclass.Argument(
+            "--foo",
+            type=int,
+            nargs="?",
+            my_extra="opt",
+        )
+        assert isinstance(arg, TypedArgument)
+        assert arg.extra_kwargs == {"my_extra": "opt"}
+
+    def test_no_extra_kwargs_means_field_is_empty_mapping(self):
+        """Without **kwargs the field is an empty immutable mapping."""
+        from argclass.store import TypedArgument
+
+        single = argclass.Argument("--a", type=int)
+        seq = argclass.Argument("--b", type=int, nargs="+")
+        opt = argclass.Argument("--c", type=int, nargs="?")
+        fallback = argclass.Argument("--d")
+
+        for arg in (single, seq, opt, fallback):
+            assert isinstance(arg, TypedArgument)
+            assert dict(arg.extra_kwargs) == {}
+
+    def test_help_action_drops_type(self):
+        """HELP action should not propagate `type` to argparse."""
+        from argclass.store import TypedArgument
+        from argclass import Actions
+
+        arg = TypedArgument(action=Actions.HELP, type=str)
+        kwargs = arg.get_kwargs()
+        assert kwargs["action"] == "help"
         assert "type" not in kwargs
 
 


### PR DESCRIPTION
This pull request introduces support for passing arbitrary keyword arguments through `Argument()`, `ArgumentSingle()`, and `ArgumentSequence()` to `argparse.ArgumentParser.add_argument()`. This enables use of argparse features not explicitly modeled by argclass, such as the `version` parameter for version actions. The implementation ensures that extra kwargs are stored immutably and merged at parser construction time, with automatic stripping of incompatible parameters for certain actions. The documentation and tests have been updated to demonstrate and validate these enhancements.

**Argparse passthrough kwargs support:**

- `argclass/factory.py`, `argclass/store.py`: Added `**extra_kwargs` to all argument factory functions and ensure they are stored as an immutable `MappingProxyType` and merged into the kwargs dict for `add_argument()`. This enables passing arbitrary argparse-specific options, such as `version=...` for `action=Actions.VERSION`. [[1]](diffhunk://#diff-bb1e37e27f172ea4f6a60f21039a9ce1c9e1e5361e3291912d850e314968812aR50-R61) [[2]](diffhunk://#diff-bb1e37e27f172ea4f6a60f21039a9ce1c9e1e5361e3291912d850e314968812aR78) [[3]](diffhunk://#diff-bb1e37e27f172ea4f6a60f21039a9ce1c9e1e5361e3291912d850e314968812aR103-R113) [[4]](diffhunk://#diff-bb1e37e27f172ea4f6a60f21039a9ce1c9e1e5361e3291912d850e314968812aR137) [[5]](diffhunk://#diff-bb1e37e27f172ea4f6a60f21039a9ce1c9e1e5361e3291912d850e314968812aR415) [[6]](diffhunk://#diff-bb1e37e27f172ea4f6a60f21039a9ce1c9e1e5361e3291912d850e314968812aR427) [[7]](diffhunk://#diff-bb1e37e27f172ea4f6a60f21039a9ce1c9e1e5361e3291912d850e314968812aR462) [[8]](diffhunk://#diff-9363e082bf483d224ffae5163dff7c13e666c05ec30b651f42e1279510d6043dL120-R152) [[9]](diffhunk://#diff-9363e082bf483d224ffae5163dff7c13e666c05ec30b651f42e1279510d6043dR166)

- [`argclass/store.py`](diffhunk://#diff-9363e082bf483d224ffae5163dff7c13e666c05ec30b651f42e1279510d6043dL120-R152): Updated the logic in `get_kwargs()` to merge extra kwargs and to automatically remove the `type` parameter for actions that do not accept it (`VERSION`, `HELP`, `STORE_TRUE`, `STORE_FALSE`, `COUNT`).

**Documentation updates:**

- `README.md`, `docs/arguments.md`, `docs/llms.txt`: Added sections and examples showing how to use the passthrough kwargs feature, including usage of the `version` parameter and details on how extra kwargs are handled and stored. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R207-R243) [[2]](diffhunk://#diff-6e7625cbc8a63d1d40606715c8eb08faa49bdfcb477566d884bcf9c1df9b76b4R564-R598) [[3]](diffhunk://#diff-c3766b99af4d08bfc9cdf445f24886eba90f863437970d4eee791c8e6053e3d8L101-R138)

- `docs/index.md`, `docs/llms.txt`: Improved and clarified interactive example instructions, highlighting the new and existing features accessible via `python -m argclass`. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L320-R332) [[2]](diffhunk://#diff-c3766b99af4d08bfc9cdf445f24886eba90f863437970d4eee791c8e6053e3d8R9-R22)

**Test and example improvements:**

- [`tests/test_simple.py`](diffhunk://#diff-61d5a1a018e97cc478eba974e6abfff036bf58e449578b7b680fab7f2e63976dL1905-R1916): Updated tests to reflect changes in main demo class and command names, and to test the enhanced passthrough functionality.

**Other improvements:**

- [`argclass/secret.py`](diffhunk://#diff-c65ead2be1e5d3f3f3e928e0924dba111b731550b7e16f54a48e93cd57ae6756R24-R31): Improved logging example for `SecretString` to ensure output is visible and consistent by configuring logging to use `sys.stdout` and `force=True`.