### PR TITLE
nested groups support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,43 @@ parser.parse_args()
 print(parser.db.host, parser.db.port)
 ```
 
+### Nested groups (Group inside Group)
+
+Groups can contain other Groups for arbitrary nesting:
+
+```python
+import argclass
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    credentials: Credentials = Credentials()
+
+class CLI(argclass.Parser):
+    endpoint: Endpoint = Endpoint()
+
+parser = CLI()
+parser.parse_args([
+    "--endpoint-host=10.0.0.1",
+    "--endpoint-credentials-username=root",
+])
+```
+
+Naming follows the attribute path:
+
+- CLI: `--endpoint-credentials-username`
+- ENV (with `auto_env_var_prefix="APP_"`): `APP_ENDPOINT_CREDENTIALS_USERNAME`
+- INI: section `[endpoint.credentials]`, key `username`
+- JSON/TOML: nested objects/tables
+
+`Group(prefix=...)` overrides only the CLI/env segment for that group;
+config section names always follow the attribute path. Reusing the
+same Group instance in two places raises `ArgclassError` (instantiate
+a separate Group per attribute).
+
 ### Subcommands
 
 ```python

--- a/README.md
+++ b/README.md
@@ -89,6 +89,36 @@ assert parser.db.host == "db.example.com"
 assert parser.db.port == 3306
 ```
 
+Groups can also contain other Groups. Names join with `-` (CLI), `_`
+(env vars), or `.` (INI/TOML sections):
+
+<!--- name: test_nested_groups_example --->
+```python
+import argclass
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    credentials: Credentials = Credentials()
+
+class Parser(argclass.Parser):
+    endpoint: Endpoint = Endpoint()
+
+parser = Parser()
+parser.parse_args([
+    "--endpoint-host", "api.example.com",
+    "--endpoint-credentials-username", "root",
+])
+assert parser.endpoint.host == "api.example.com"
+assert parser.endpoint.credentials.username == "root"
+```
+
+See [Groups](https://docs.argclass.com/groups.html#nested-groups) for
+nested groups in config files, environment variables, and `--help`.
+
 ### Configuration Files
 
 Load default values from configuration files. INI by default, JSON/TOML via `config_parser_class`.

--- a/argclass/__main__.py
+++ b/argclass/__main__.py
@@ -220,7 +220,7 @@ class GroupsDemo(argclass.Parser):
       class CLI(argclass.Parser):
           endpoint: Endpoint = Endpoint()
 
-    Nested groups produce dot-joined CLI flags
+    Nested groups produce hyphen-joined CLI flags
     (--endpoint-credentials-username), env vars
     (PREFIX_ENDPOINT_CREDENTIALS_USERNAME), and INI
     sections ([endpoint.credentials]).

--- a/argclass/__main__.py
+++ b/argclass/__main__.py
@@ -220,9 +220,9 @@ class GroupsDemo(argclass.Parser):
       class CLI(argclass.Parser):
           endpoint: Endpoint = Endpoint()
 
-    Nested groups produce hyphen-joined CLI flags
-    (--endpoint-credentials-username), env vars
-    (PREFIX_ENDPOINT_CREDENTIALS_USERNAME), and INI
+    Nested groups join segments with `-` for CLI flags
+    (--endpoint-credentials-username), `_` for env vars
+    (PREFIX_ENDPOINT_CREDENTIALS_USERNAME), and `.` for INI
     sections ([endpoint.credentials]).
 
     Try: groups --server-host 0.0.0.0 --server-port 9090 \\

--- a/argclass/__main__.py
+++ b/argclass/__main__.py
@@ -83,6 +83,17 @@ class DatabaseGroup(argclass.Group):
     name: str = "mydb"
 
 
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    port: int = 9000
+    credentials: Credentials = Credentials()
+
+
 # -- Subcommand: basic -------------------------------------------
 
 
@@ -192,30 +203,31 @@ class TypesDemo(argclass.Parser):
 
 
 class GroupsDemo(argclass.Parser):
-    """Demonstrates argument groups with prefixes.
+    """Demonstrates argument groups, including nesting.
 
     Groups organize related arguments and add prefixes
-    to avoid name collisions:
+    to avoid name collisions. Groups can also contain
+    other Groups for arbitrary nesting:
 
-      class ServerGroup(argclass.Group):
-          host: str = "localhost"
-          port: int = 8080
+      class Credentials(argclass.Group):
+          username: str = "admin"
+          password: str = "secret"
 
-      class DatabaseGroup(argclass.Group):
+      class Endpoint(argclass.Group):
           host: str = "localhost"
-          port: int = 5432
+          credentials: Credentials = Credentials()
 
       class CLI(argclass.Parser):
-          server = ServerGroup(title="Server options")
-          db = DatabaseGroup(
-              title="Database options", prefix="db",
-          )
+          endpoint: Endpoint = Endpoint()
 
-    Both groups have 'host' and 'port', but CLI flags
-    are --server-host/--server-port vs --db-host/--db-port.
+    Nested groups produce dot-joined CLI flags
+    (--endpoint-credentials-username), env vars
+    (PREFIX_ENDPOINT_CREDENTIALS_USERNAME), and INI
+    sections ([endpoint.credentials]).
 
     Try: groups --server-host 0.0.0.0 --server-port 9090 \\
-               --db-host db.local --db-port 3306 --db-name app
+               --db-host db.local --db-port 3306 --db-name app \\
+               --endpoint-credentials-username root
     """
 
     server: ServerGroup = ServerGroup(title="Server options")
@@ -223,9 +235,10 @@ class GroupsDemo(argclass.Parser):
         title="Database options",
         prefix="db",
     )
+    endpoint: Endpoint = Endpoint(title="Endpoint (nested groups demo)")
 
     def __call__(self) -> int:
-        print_source(self.server, self.db, self)
+        print_source(self.server, self.db, self.endpoint, Credentials, self)
         print("== Argument Groups ==\n")
         print("  Server group (prefix='server'):")
         print(f"    --server-host = {self.server.host!r}")
@@ -236,10 +249,25 @@ class GroupsDemo(argclass.Parser):
         print(f"    --db-port     = {self.db.port!r}")
         print(f"    --db-name     = {self.db.name!r}")
         print()
+        print("  Endpoint group with nested Credentials:")
+        print(
+            f"    --endpoint-host                    = {self.endpoint.host!r}"
+        )
+        print(
+            f"    --endpoint-credentials-username    = "
+            f"{self.endpoint.credentials.username!r}"
+        )
+        print(
+            f"    --endpoint-credentials-password    = "
+            f"{self.endpoint.credentials.password!r}"
+        )
+        print()
         print("How it works:")
         print("  - Group name or explicit prefix= avoids")
         print("    collisions when fields have the same name")
         print("  - Each group gets its own section in --help")
+        print("  - Groups can contain other Groups; CLI/env/INI")
+        print("    names join with -, _, or . respectively")
         return 0
 
 

--- a/argclass/defaults.py
+++ b/argclass/defaults.py
@@ -100,7 +100,12 @@ class AbstractDefaultsParser(ABC):
         Args:
             key: The config key name.
             kind: Expected value type for validation.
-            section: Optional section/group name for nested values.
+            section: Optional section/group name for nested values. May
+                contain dots to address nested groups (e.g.
+                ``"endpoint.credentials"``). Resolution tries a literal
+                key match first (so INI section names with dots work),
+                then falls back to splitting on ``.`` and descending
+                through nested dicts (JSON/TOML).
 
         Returns:
             The value, converted if necessary (e.g., INI literal_eval).
@@ -109,9 +114,17 @@ class AbstractDefaultsParser(ABC):
             UnexpectedConfigValue: If value doesn't match expected kind.
         """
         if section is not None:
-            source = self._values.get(section, {})
+            source: Any = self._values.get(section)
             if not isinstance(source, dict):
-                return None
+                source = self._values
+                for part in section.split("."):
+                    if not isinstance(source, dict):
+                        return None
+                    source = source.get(part)
+                    if source is None:
+                        return None
+                if not isinstance(source, dict):
+                    return None
         else:
             source = self._values
 

--- a/argclass/defaults.py
+++ b/argclass/defaults.py
@@ -97,15 +97,16 @@ class AbstractDefaultsParser(ABC):
     ) -> Any:
         """Get value with type validation.
 
+        The ``section`` argument may contain dots to address nested
+        groups (e.g. ``"endpoint.credentials"``). Resolution tries a
+        literal key match first (so INI section names with dots work),
+        then falls back to splitting on ``.`` and descending through
+        nested dicts (JSON/TOML).
+
         Args:
             key: The config key name.
             kind: Expected value type for validation.
-            section: Optional section/group name for nested values. May
-                contain dots to address nested groups (e.g.
-                ``"endpoint.credentials"``). Resolution tries a literal
-                key match first (so INI section names with dots work),
-                then falls back to splitting on ``.`` and descending
-                through nested dicts (JSON/TOML).
+            section: Optional section/group name for nested values.
 
         Returns:
             The value, converted if necessary (e.g., INI literal_eval).

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -33,6 +33,7 @@ from .defaults import (
 from .exceptions import (
     ArgclassError,
     ArgumentDefinitionError,
+    ComplexTypeError,
     TypeConversionError,
 )
 from .secret import SecretString
@@ -104,8 +105,61 @@ class Meta(ABCMeta):
 
             try:
                 argument = deep_getattr(key, attrs, *bases)
+                has_explicit_default = True
             except KeyError:
                 argument = None
+                has_explicit_default = False
+
+            annotated_group_cls: Optional[Type[AbstractGroup]] = None
+            if isinstance(kind, type) and issubclass(kind, AbstractGroup):
+                annotated_group_cls = kind
+            else:
+                try:
+                    optional_inner = unwrap_optional(kind)
+                except ComplexTypeError:
+                    optional_inner = None
+                if (
+                    optional_inner is not None
+                    and isinstance(optional_inner, type)
+                    and issubclass(optional_inner, AbstractGroup)
+                ):
+                    raise ArgumentDefinitionError(
+                        f"Group field '{key}' cannot be Optional. Group "
+                        f"instances hold parsed state and cannot be None.",
+                        field_name=key,
+                        hint=(
+                            f"Use '{key}: {optional_inner.__name__}' "
+                            f"(auto-instantiated) or "
+                            f"'{key}: {optional_inner.__name__} = "
+                            f"{optional_inner.__name__}()'."
+                        ),
+                    )
+
+            if annotated_group_cls is not None:
+                if isinstance(argument, AbstractGroup):
+                    if not isinstance(argument, annotated_group_cls):
+                        raise ArgumentDefinitionError(
+                            f"Group field '{key}' annotated as "
+                            f"{annotated_group_cls.__name__} but assigned "
+                            f"an incompatible instance of "
+                            f"{type(argument).__name__}",
+                            field_name=key,
+                        )
+                elif not has_explicit_default or argument is Ellipsis:
+                    argument = annotated_group_cls()
+                    setattr(cls, key, argument)
+                else:
+                    raise ArgumentDefinitionError(
+                        f"Group field '{key}' got a non-Group default "
+                        f"value: {argument!r}",
+                        field_name=key,
+                        hint=(
+                            f"Use '{key}: {annotated_group_cls.__name__}' "
+                            f"(auto-instantiated) or "
+                            f"'{key}: {annotated_group_cls.__name__} = "
+                            f"{annotated_group_cls.__name__}()'."
+                        ),
+                    )
 
             if not isinstance(
                 argument,

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -30,7 +30,11 @@ from .defaults import (
     INIDefaultsParser,
     ValueKind,
 )
-from .exceptions import ArgumentDefinitionError, TypeConversionError
+from .exceptions import (
+    ArgclassError,
+    ArgumentDefinitionError,
+    TypeConversionError,
+)
 from .secret import SecretString
 from .store import AbstractGroup, AbstractParser, TypedArgument
 from .types import Actions, Nargs
@@ -604,76 +608,127 @@ class Parser(AbstractParser, Base):
         destinations: DestinationsType,
         parser: ArgumentParser,
     ) -> None:
+        visited: Set[int] = set()
         for group_name, group in self.__argument_groups__.items():
-            group_parser = parser.add_argument_group(
-                title=group._title,
-                description=group._description,
+            cli_seg = group._prefix if group._prefix is not None else group_name
+            cli_path: Tuple[str, ...] = (cli_seg,) if cli_seg else ()
+            self._fill_group(
+                group=group,
+                parser=parser,
+                attr_path=(group_name,),
+                cli_path=cli_path,
+                destinations=destinations,
+                visited=visited,
             )
 
-            for name, argument in group.__arguments__.items():
-                aliases = set(argument.aliases)
-                if group._prefix is not None:
-                    prefix = group._prefix
+    def _fill_group(
+        self,
+        group: "Group",
+        parser: ArgumentParser,
+        attr_path: Tuple[str, ...],
+        cli_path: Tuple[str, ...],
+        destinations: DestinationsType,
+        visited: Set[int],
+    ) -> None:
+        if id(group) in visited:
+            raise ArgclassError(
+                "Group instance is referenced more than once in the parser "
+                f"tree (current path: {'.'.join(attr_path)}). Reusing a "
+                "single Group instance across attributes is not supported "
+                "because state would be shared between locations.",
+                hint="Instantiate a new Group for each attribute, or "
+                "subclass Group to define a dedicated type.",
+            )
+        visited.add(id(group))
+
+        section = ".".join(attr_path)
+        cli_prefix = "_".join(cli_path)
+
+        title = group._title
+        if title is None and len(attr_path) > 1:
+            title = section
+
+        group_parser = parser.add_argument_group(
+            title=title,
+            description=group._description,
+        )
+
+        for name, argument in group.__arguments__.items():
+            aliases = set(argument.aliases)
+            dest = f"{cli_prefix}_{name}" if cli_prefix else name
+
+            if not aliases:
+                aliases.add(f"--{self.get_cli_name(dest)}")
+
+            # Get default from config with type-aware loading
+            kind = self._get_value_kind(argument)
+            config_default = self._config_parser.get_value(
+                name,
+                kind,
+                section=section,
+            )
+
+            # Apply type converter to config values
+            if config_default is not None and argument.type is not None:
+                type_func = argument.type
+                if isinstance(config_default, (list, tuple)):
+                    config_default = [type_func(x) for x in config_default]
                 else:
-                    prefix = group_name
-                dest = f"{prefix}_{name}" if prefix else name
+                    val = config_default
+                    try:
+                        already_correct = isinstance(val, type_func)
+                    except TypeError:
+                        already_correct = False
+                    if not already_correct:
+                        config_default = type_func(val)
 
-                if not aliases:
-                    aliases.add(f"--{self.get_cli_name(dest)}")
+            default = (
+                config_default
+                if config_default is not None
+                else group._defaults.get(name, argument.default)
+            )
 
-                # Get default from config with type-aware loading
-                kind = self._get_value_kind(argument)
-                config_default = self._config_parser.get_value(
-                    name,
-                    kind,
-                    section=group_name,
-                )
+            argument = argument.copy(
+                default=default,
+                env_var=self.get_env_var(dest, argument),
+            )
 
-                # Apply type converter to config values
-                if config_default is not None and argument.type is not None:
-                    type_func = argument.type
-                    if isinstance(config_default, (list, tuple)):
-                        config_default = [type_func(x) for x in config_default]
-                    else:
-                        # Check if already correct type (only for types)
-                        val = config_default
-                        try:
-                            already_correct = isinstance(val, type_func)
-                        except TypeError:
-                            already_correct = False
-                        if not already_correct:
-                            config_default = type_func(val)
+            is_optional = any(a.startswith("-") for a in aliases)
+            if is_optional and argument.has_default and argument.required:
+                argument = argument.copy(required=False)
 
-                default = (
-                    config_default
-                    if config_default is not None
-                    else group._defaults.get(name, argument.default)
-                )
+            dest, action = self._add_argument(
+                group_parser,
+                argument,
+                dest,
+                *aliases,
+            )
+            destinations[dest].add(
+                Destination(
+                    target=group,
+                    attribute=name,
+                    argument=argument,
+                    action=action,
+                ),
+            )
 
-                argument = argument.copy(
-                    default=default,
-                    env_var=self.get_env_var(dest, argument),
-                )
-
-                # Check if this will be an optional argument (has -- prefix)
-                is_optional = any(a.startswith("-") for a in aliases)
-                if is_optional and argument.has_default and argument.required:
-                    argument = argument.copy(required=False)
-
-                dest, action = self._add_argument(
-                    group_parser,
-                    argument,
-                    dest,
-                    *aliases,
-                )
-                destinations[dest].add(
-                    Destination(
-                        target=group,
-                        attribute=name,
-                        argument=argument,
-                        action=action,
-                    ),
-                )
+        for child_name, child_group in group.__argument_groups__.items():
+            child_cli_seg = (
+                child_group._prefix
+                if child_group._prefix is not None
+                else child_name
+            )
+            child_cli_path = cli_path + (
+                (child_cli_seg,) if child_cli_seg else ()
+            )
+            self._fill_group(
+                group=child_group,
+                parser=parser,
+                attr_path=attr_path + (child_name,),
+                cli_path=child_cli_path,
+                destinations=destinations,
+                visited=visited,
+            )
 
     def _fill_subparsers(
         self,

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -118,6 +118,32 @@ class Meta(ABCMeta):
                     optional_inner = unwrap_optional(kind)
                 except ComplexTypeError:
                     optional_inner = None
+                    # Complex union (e.g. `G | int`, `G | None | int`,
+                    # `G1 | G2`). If any member is a Group, raise a
+                    # Group-specific message — otherwise the generic
+                    # argument path raises the same ComplexTypeError
+                    # without mentioning Group, which is confusing.
+                    union_groups = [
+                        arg
+                        for arg in getattr(kind, "__args__", ())
+                        if isinstance(arg, type)
+                        and issubclass(arg, AbstractGroup)
+                    ]
+                    if union_groups:
+                        g = union_groups[0]
+                        raise ArgumentDefinitionError(
+                            f"Group field '{key}' cannot be part of a "
+                            f"complex Union ({kind!r}). Group instances "
+                            f"hold parsed state and only one Group "
+                            f"class is meaningful per attribute.",
+                            field_name=key,
+                            hint=(
+                                f"Use '{key}: {g.__name__}' "
+                                f"(auto-instantiated) or "
+                                f"'{key}: {g.__name__} = "
+                                f"{g.__name__}()'."
+                            ),
+                        )
                 if (
                     optional_inner is not None
                     and isinstance(optional_inner, type)

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -640,6 +640,84 @@ assert parser.database.port == 3306
 Path(config_path).unlink()
 ```
 
+#### Nested Groups in Config Files
+
+A group inside a group becomes a dotted INI section, a nested JSON/TOML
+table, or a child object — depending on the format.
+
+INI uses the dotted section name verbatim:
+
+<!--- name: test_config_nested_ini --->
+```python
+import argclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    credentials: Credentials = Credentials()
+
+class Parser(argclass.Parser):
+    endpoint: Endpoint = Endpoint()
+
+CONFIG = """
+[endpoint]
+host = api.example.com
+
+[endpoint.credentials]
+username = root
+password = hunter2
+"""
+
+with NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+    f.write(CONFIG)
+    config_path = f.name
+
+parser = Parser(config_files=[config_path])
+parser.parse_args([])
+
+assert parser.endpoint.host == "api.example.com"
+assert parser.endpoint.credentials.username == "root"
+assert parser.endpoint.credentials.password == "hunter2"
+
+Path(config_path).unlink()
+```
+
+JSON uses natural nesting — each group level is a nested object:
+
+```json
+{
+  "endpoint": {
+    "host": "api.example.com",
+    "credentials": {
+      "username": "root",
+      "password": "hunter2"
+    }
+  }
+}
+```
+
+TOML uses dotted table headers, just like INI:
+
+```toml
+[endpoint]
+host = "api.example.com"
+
+[endpoint.credentials]
+username = "root"
+password = "hunter2"
+```
+
+:::{note}
+The section name in config files always follows the attribute path,
+even when a group has `prefix=` set. `prefix=` only renames the CLI/env
+segment for that group.
+:::
+
 ### Boolean Values
 
 | True values | False values |

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -97,6 +97,43 @@ del os.environ["APP_DATABASE_HOST"]
 del os.environ["APP_DATABASE_PORT"]
 ```
 
+### Nested Groups
+
+Nested group fields use the full attribute path joined with `_`, then
+uppercased:
+
+<!--- name: test_env_nested_groups --->
+```python
+import os
+import argclass
+
+os.environ["APP_ENDPOINT_HOST"] = "api.example.com"
+os.environ["APP_ENDPOINT_CREDENTIALS_USERNAME"] = "root"
+os.environ["APP_ENDPOINT_CREDENTIALS_PASSWORD"] = "hunter2"
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    credentials: Credentials = Credentials()
+
+class Parser(argclass.Parser):
+    endpoint: Endpoint = Endpoint()
+
+parser = Parser(auto_env_var_prefix="APP_")
+parser.parse_args([])
+
+assert parser.endpoint.host == "api.example.com"
+assert parser.endpoint.credentials.username == "root"
+assert parser.endpoint.credentials.password == "hunter2"
+
+del os.environ["APP_ENDPOINT_HOST"]
+del os.environ["APP_ENDPOINT_CREDENTIALS_USERNAME"]
+del os.environ["APP_ENDPOINT_CREDENTIALS_PASSWORD"]
+```
+
 ## Priority
 
 Environment variables override config files but are overridden by CLI arguments:

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -205,6 +205,135 @@ assert parser.database.host == "db.example.com"
 assert parser.database.port == 5432
 ```
 
+## Nested Groups
+
+Groups can contain other Groups as fields. This works for any depth and
+keeps `Parser → Group → Group → ...` cleanly modelled in code. Names are
+built by joining the attribute path with the appropriate separator for
+each source:
+
+| Source | Separator | Example                                       |
+|--------|-----------|-----------------------------------------------|
+| CLI    | `-`       | `--endpoint-credentials-username`             |
+| ENV    | `_`       | `<PREFIX>ENDPOINT_CREDENTIALS_USERNAME`       |
+| INI    | `.`       | `[endpoint.credentials]` section, `username`  |
+| JSON   | nested    | `{"endpoint": {"credentials": {"username":…}}}` |
+| TOML   | `.`       | `[endpoint.credentials]` table, `username`    |
+
+<!--- name: test_groups_nested_cli --->
+```python
+import argclass
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    port: int = 8080
+    credentials: Credentials = Credentials()
+
+class Parser(argclass.Parser):
+    endpoint: Endpoint = Endpoint()
+
+parser = Parser()
+parser.parse_args([
+    "--endpoint-host", "api.example.com",
+    "--endpoint-credentials-username", "root",
+    "--endpoint-credentials-password", "hunter2",
+])
+
+assert parser.endpoint.host == "api.example.com"
+assert parser.endpoint.credentials.username == "root"
+assert parser.endpoint.credentials.password == "hunter2"
+```
+
+Nested groups appear as separate sections in `--help`, titled with their
+dotted attribute path (e.g. `endpoint.credentials`). Set `title=` on a
+group to override the default title for that one level.
+
+### Nested groups in config files
+
+INI sections use a dotted section name; JSON/TOML use natural nesting.
+
+<!--- name: test_groups_nested_ini --->
+```python
+import argclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    credentials: Credentials = Credentials()
+
+class Parser(argclass.Parser):
+    endpoint: Endpoint = Endpoint()
+
+CONFIG = """
+[endpoint]
+host = api.example.com
+
+[endpoint.credentials]
+username = root
+password = hunter2
+"""
+
+with NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+    f.write(CONFIG)
+    config_path = f.name
+
+parser = Parser(config_files=[config_path])
+parser.parse_args([])
+
+assert parser.endpoint.host == "api.example.com"
+assert parser.endpoint.credentials.username == "root"
+assert parser.endpoint.credentials.password == "hunter2"
+
+Path(config_path).unlink()
+```
+
+### `prefix=` and nested groups
+
+`Group(prefix=...)` overrides only the CLI/ENV segment for that group. It
+does **not** affect the INI/TOML section name — config sections always
+follow the attribute path. This keeps section names predictable and
+prevents CLI prefixes from silently desyncing from config layout.
+
+### Reusing a group instance is an error
+
+Passing the same `Group` instance to two different attributes raises
+`ArgclassError`, because that group's parsed state would otherwise be
+shared between locations. Instantiate a separate group per attribute,
+or subclass `Group` to define a dedicated type:
+
+<!--- name: test_groups_nested_separate_instances --->
+```python
+import argclass
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+
+class Auth(argclass.Group):
+    primary: Credentials = Credentials()      # separate instance
+    secondary: Credentials = Credentials()    # separate instance
+
+class Parser(argclass.Parser):
+    auth: Auth = Auth()
+
+parser = Parser()
+parser.parse_args([
+    "--auth-primary-username", "alice",
+    "--auth-secondary-username", "bob",
+])
+
+assert parser.auth.primary.username == "alice"
+assert parser.auth.secondary.username == "bob"
+```
+
 ## Groups in Config Files
 
 Groups map to INI sections. The section name matches the group attribute name.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -4,6 +4,50 @@ Groups organize related arguments together and enable reuse across parsers.
 They provide logical structure to your CLI, make `--help` output more readable,
 and allow you to define common argument sets once and reuse them in multiple parsers.
 
+## The Mental Model: a Group Instance Is a Declaration, not a Parser
+
+A `Group()` you assign on a parser class — `db = DatabaseGroup()` or
+`db: DatabaseGroup = DatabaseGroup(defaults={...})` — is a **declaration
+of structure and per-instance defaults**, not a runtime parser. You
+don't call methods on it; you don't use it to read CLI arguments. Its
+job at class-definition time is to:
+
+- name a slot in the parsed result (`parser.db`),
+- describe which arguments belong to that slot (via its annotations),
+- optionally override defaults for this particular slot (`defaults=`,
+  `title=`, `prefix=`).
+
+When you call `Parser().parse_args(...)`, argclass walks these
+declarations, builds an `argparse` parser from them, parses the
+command line, and then writes the parsed values back into the same
+group instance so you can read them as `parser.db.host`. The instance
+is a write target during parsing, not an active participant in it.
+
+Two consequences worth internalising:
+
+1. **Don't call parser methods on a `Group` instance.** It has no
+   `parse_args()`. Groups are not standalone parsers.
+2. **Don't share one `Group` instance across two attributes.** Since
+   the instance holds the parsed state for *its* slot, assigning the
+   same instance to `primary = shared` and `secondary = shared` would
+   make them aliases of one another — argclass raises
+   `ArgclassError` at parse time to prevent this. Construct one
+   `Group()` per slot. (Using the same Group *class* twice is fine —
+   only sharing a single constructed instance is not.)
+
+:::{note}
+**Groups vs. subparsers.** This "instance-is-a-declaration" rule is
+specific to `Group`. **Subparsers are different**: a subparser is a
+`Parser` subclass instance assigned to an attribute (e.g.
+`serve = Serve()`), and at runtime the selected subparser really does
+parse its own slice of `sys.argv` — it has a working `parse_args()`,
+its own `__call__`, its own subparsers. Subparsers are real parsers
+chosen by name from the CLI; groups are namespaced collections of
+arguments declared upfront. If you want a runnable sub-command, use a
+subparser. If you want to bundle related options under a prefix, use a
+group. See [Subparsers](subparsers.md) for the runtime contract.
+:::
+
 ## Basic Groups
 
 Create a group by inheriting from `argclass.Group`. When you add a group to a
@@ -302,6 +346,45 @@ Path(config_path).unlink()
 does **not** affect the INI/TOML section name — config sections always
 follow the attribute path. This keeps section names predictable and
 prevents CLI prefixes from silently desyncing from config layout.
+
+### Group fields with type annotations
+
+A group attribute can be declared with a type annotation. When the
+annotation refers to a `Group` subclass, argclass enforces these rules
+at class definition time:
+
+| Form                                | Behaviour                       |
+|-------------------------------------|---------------------------------|
+| `g: G`                              | Auto-instantiated as `G()`      |
+| `g: G = G()`                        | Uses the provided instance      |
+| `g: G = ...` (Ellipsis sentinel)    | Auto-instantiated as `G()`      |
+| `g = G()` (no annotation)           | Uses the provided instance      |
+| `g: G \| None = None`               | **Rejected** (Group can't be None) |
+| `g: G = None`                       | **Rejected** (Group can't be None) |
+| `g: G = G2()` (wrong Group class)   | **Rejected**                    |
+| `g: G = "anything-not-a-G"`         | **Rejected**                    |
+
+<!--- name: test_groups_annotation_auto_instantiate --->
+```python
+import argclass
+
+class DatabaseGroup(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+
+class Parser(argclass.Parser):
+    # No explicit default — argclass instantiates DatabaseGroup() for you
+    database: DatabaseGroup
+
+parser = Parser()
+parser.parse_args(["--database-host", "db.example.com"])
+
+assert parser.database.host == "db.example.com"
+assert parser.database.port == 5432
+```
+
+Rejected forms raise `ArgumentDefinitionError` immediately when the
+parser class is defined, with a hint suggesting the correct form.
 
 ### Reusing a group instance is an error
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -337,7 +337,9 @@ $ python -m argclass subcommands hello --user Alice
 ### Groups
 
 Organize related arguments into reusable groups. Group arguments are
-automatically prefixed with the group name:
+automatically prefixed with the group name. Groups can also be nested
+inside other groups for arbitrary depth — names join with `-` (CLI),
+`_` (env vars), or `.` (INI/TOML sections):
 
 <!--- name: test_groups_basic --->
 ```python

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # argclass
 
-## Docs markdown files splitted by topic for easier navigation and LLM processing:
+## Docs markdown files split by topic for easier navigation and LLM processing:
 
 The links below point to the **raw Markdown source** of each
 documentation page (`/_sources/<topic>.md.txt` on docs.argclass.com),

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,5 +1,26 @@
 # argclass
 
+## Docs markdown files splitted by topic for easier navigation and LLM processing:
+
+- [Quick Start](https://docs.argclass.com/_sources/quickstart.md.txt): 5-minute overview of essential concepts
+- [Tutorial](https://docs.argclass.com/_sources/tutorial.md.txt): 30-minute guide building a complete CLI application
+- [Arguments](https://docs.argclass.com/_sources/arguments.md.txt): Typed arguments, defaults, nargs, enums, boolean flags
+- [Groups](https://docs.argclass.com/_sources/groups.md.txt): Reusable argument groups with prefix support
+- [Subparsers](https://docs.argclass.com/_sources/subparsers.md.txt): Hierarchical subcommands and nested parsers
+- [Config Files](https://docs.argclass.com/_sources/config-files.md.txt): INI, JSON, and TOML configuration file support
+- [Environment Variables](https://docs.argclass.com/_sources/environment.md.txt): Automatic env var binding with prefixes
+- [Secrets](https://docs.argclass.com/_sources/secrets.md.txt): Secret masking to prevent accidental exposure in logs
+- [API Reference](https://docs.argclass.com/api.html): Full API documentation with all classes and functions
+
+## Optional
+
+- [Examples Gallery](https://docs.argclass.com/_sources/examples.md.txt): Ready-to-use patterns from simple CLIs to multi-command tools
+- [Error Handling](https://docs.argclass.com/_sources/errors.md.txt): Error types and handling strategies
+- [Common Pitfalls](https://docs.argclass.com/_sources/pitfalls.md.txt): Frequent mistakes and how to avoid them
+- [Integrations](https://docs.argclass.com/_sources/integrations.md.txt): Using argclass with other tools
+- [Security](https://docs.argclass.com/_sources/security.md.txt): Security policy and best practices
+
+
 > A Python library for building type-safe command-line interfaces using declarative classes with type hints, configuration files, and environment variables. Zero external dependencies. Requires Python 3.10+.
 
 argclass wraps Python's standard `argparse` module, letting you describe argument parsers as classes with type annotations instead of imperative `add_argument()` calls. It supports INI/JSON/TOML config files, environment variable binding, secret masking, argument groups, and hierarchical subcommands — all with full IDE autocompletion.
@@ -68,6 +89,29 @@ parser.parse_args()
 print(parser.db.host, parser.db.port)
 ```
 
+### Nested groups (Group inside Group)
+
+Groups can contain other Groups for arbitrary depth. Names join with `-` for CLI, `_` for environment variables, and `.` for INI/TOML sections (JSON/TOML also support natural nesting). `Group(prefix=...)` overrides only the CLI/env segment; config section names always follow the attribute path. Reusing the same Group instance in two places raises `ArgclassError` — instantiate a separate Group per attribute instead.
+
+```python
+import argclass
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    credentials: Credentials = Credentials()
+
+class CLI(argclass.Parser):
+    endpoint: Endpoint = Endpoint()
+
+# CLI: --endpoint-host, --endpoint-credentials-username
+# ENV: <PREFIX>ENDPOINT_HOST, <PREFIX>ENDPOINT_CREDENTIALS_USERNAME
+# INI: [endpoint], [endpoint.credentials]
+```
+
 ### Subcommands
 
 ```python
@@ -134,23 +178,3 @@ except SystemExit:
 ```
 
 argclass automatically strips `type=` for `VERSION`, `HELP`, `STORE_TRUE`, `STORE_FALSE`, and `COUNT` actions (argparse rejects it). Extra kwargs are frozen as an immutable `MappingProxyType` and merged into the dict passed to `add_argument()`.
-
-## Docs markdown files splitted by topic for easier navigation and LLM processing:
-
-- [Quick Start](https://docs.argclass.com/_sources/quickstart.md.txt): 5-minute overview of essential concepts
-- [Tutorial](https://docs.argclass.com/_sources/tutorial.md.txt): 30-minute guide building a complete CLI application
-- [Arguments](https://docs.argclass.com/_sources/arguments.md.txt): Typed arguments, defaults, nargs, enums, boolean flags
-- [Groups](https://docs.argclass.com/_sources/groups.md.txt): Reusable argument groups with prefix support
-- [Subparsers](https://docs.argclass.com/_sources/subparsers.md.txt): Hierarchical subcommands and nested parsers
-- [Config Files](https://docs.argclass.com/_sources/config-files.md.txt): INI, JSON, and TOML configuration file support
-- [Environment Variables](https://docs.argclass.com/_sources/environment.md.txt): Automatic env var binding with prefixes
-- [Secrets](https://docs.argclass.com/_sources/secrets.md.txt): Secret masking to prevent accidental exposure in logs
-- [API Reference](https://docs.argclass.com/api.html): Full API documentation with all classes and functions
-
-## Optional
-
-- [Examples Gallery](https://docs.argclass.com/_sources/examples.md.txt): Ready-to-use patterns from simple CLIs to multi-command tools
-- [Error Handling](https://docs.argclass.com/_sources/errors.md.txt): Error types and handling strategies
-- [Common Pitfalls](https://docs.argclass.com/_sources/pitfalls.md.txt): Frequent mistakes and how to avoid them
-- [Integrations](https://docs.argclass.com/_sources/integrations.md.txt): Using argclass with other tools
-- [Security](https://docs.argclass.com/_sources/security.md.txt): Security policy and best practices

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,6 +2,13 @@
 
 ## Docs markdown files splitted by topic for easier navigation and LLM processing:
 
+The links below point to the **raw Markdown source** of each
+documentation page (`/_sources/<topic>.md.txt` on docs.argclass.com),
+not the rendered HTML. Prefer these for LLM consumption: they are the
+exact authored text — no HTML scaffolding, no navigation chrome, no
+JavaScript — so you can read them directly without HTML parsing or
+content extraction.
+
 - [Quick Start](https://docs.argclass.com/_sources/quickstart.md.txt): 5-minute overview of essential concepts
 - [Tutorial](https://docs.argclass.com/_sources/tutorial.md.txt): 30-minute guide building a complete CLI application
 - [Arguments](https://docs.argclass.com/_sources/arguments.md.txt): Typed arguments, defaults, nargs, enums, boolean flags

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -209,6 +209,38 @@ class Parser(argclass.Parser):
 ```
 :::
 
+### Reusing a Group instance across attributes
+
+Each `Group` instance owns the parsed state for one location in the
+parser tree. Assigning the **same instance** to two attributes raises
+`ArgclassError`, because parsed values would otherwise be shared
+between both locations.
+
+```python
+import argclass
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+
+shared = Credentials()
+
+class Parser(argclass.Parser):
+    primary = shared      # WRONG - same instance
+    secondary = shared    # ArgclassError at parse_args time
+```
+
+Create a separate instance for each attribute instead:
+
+```python
+class Parser(argclass.Parser):
+    primary = Credentials()      # RIGHT - distinct instances
+    secondary = Credentials()
+```
+
+Using the same `Group` **class** twice (with different `Group()` calls)
+is fully supported — only sharing one already-constructed instance is
+disallowed.
+
 ---
 
 ## Subcommands

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -225,9 +225,14 @@ class Credentials(argclass.Group):
 shared = Credentials()
 
 class Parser(argclass.Parser):
-    primary = shared      # WRONG - same instance
-    secondary = shared    # ArgclassError at parse_args time
+    primary = shared      # OK on its own — single binding
+    secondary = shared    # Together with `primary`, raises ArgclassError
+                          # at parse_args time (same instance bound twice)
 ```
+
+A single attribute bound to an externally-created Group is fine; the
+error only fires when the **same instance** is reachable through two
+or more attributes at parse time.
 
 Create a separate instance for each attribute instead:
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -185,6 +185,48 @@ assert backup.compression.level == 9
 assert backup.compression.format == "lzma"
 ```
 
+Groups can also contain other Groups, which is handy when settings have
+their own sub-settings (for example, encryption inside compression). Names
+join with `-` for CLI, `_` for env vars, and `.` for INI/TOML sections:
+
+<!--- name: test_tutorial_nested_groups --->
+```python
+import argclass
+from pathlib import Path
+
+class EncryptionOptions(argclass.Group):
+    """Encryption settings, nested under compression."""
+    enabled: bool = False
+    algorithm: str = "aes-256"
+
+class CompressionOptions(argclass.Group):
+    """Compression settings with nested encryption."""
+    enabled: bool = False
+    level: int = 6
+    encryption: EncryptionOptions = EncryptionOptions()
+
+class BackupTool(argclass.Parser):
+    source: Path
+    destination: Path
+    compression: CompressionOptions = CompressionOptions()
+
+backup = BackupTool()
+backup.parse_args([
+    "--source", "/data",
+    "--destination", "/backup",
+    "--compression-enabled",
+    "--compression-encryption-enabled",
+    "--compression-encryption-algorithm", "chacha20",
+])
+
+assert backup.compression.enabled is True
+assert backup.compression.encryption.enabled is True
+assert backup.compression.encryption.algorithm == "chacha20"
+```
+
+See [Groups → Nested Groups](groups.md#nested-groups) for the full rules
+on config files and environment variables.
+
 ### Adding Subcommands
 
 For tools with multiple operations, use subcommands. Each subcommand is a

--- a/tests/test_nested_groups.py
+++ b/tests/test_nested_groups.py
@@ -196,6 +196,25 @@ class TestINI:
         assert parser.endpoint.host == "only-host"
         assert parser.endpoint.credentials.username == "admin"
 
+    def test_non_dict_intermediate_in_dotted_path_returns_default(
+        self,
+        tmp_path: Path,
+    ):
+        """If an intermediate config value on the dotted descent path
+        is not a dict (e.g. a string), get_value falls back to the
+        argument's own default instead of crashing."""
+        cfg = tmp_path / "config.json"
+        # endpoint.credentials would descend into "not-a-dict", which
+        # is not a dict — should return None and fall back to defaults.
+        cfg.write_text('{"endpoint": "not-a-dict"}')
+        parser = CLI(
+            config_files=[cfg],
+            config_parser_class=JSONDefaultsParser,
+        )
+        parser.parse_args([])
+        assert parser.endpoint.credentials.username == "admin"
+        assert parser.endpoint.credentials.password == "secret"
+
     def test_three_level_ini(self, tmp_path: Path):
         class TLS(argclass.Group):
             cert: str = "/etc/cert"
@@ -417,6 +436,28 @@ class TestGroupAnnotation:
         parser = P()
         parser.parse_args(["--outer-inner-value=set"])
         assert parser.outer.inner.value == "set"
+
+    def test_complex_union_annotation_does_not_break_group_detection(self):
+        """Fields with unsupported Union types (e.g. int | str) must
+        not raise during class definition just because we probe for
+        Group membership — they should still reach the regular
+        argument path."""
+
+        def coerce(v: str) -> object:
+            try:
+                return int(v)
+            except ValueError:
+                return v
+
+        class P(argclass.Parser):
+            value: int | str = argclass.Argument(
+                type=coerce,
+                default=0,
+            )
+
+        parser = P()
+        parser.parse_args(["--value", "42"])
+        assert parser.value == 42
 
 
 class TestSameInstanceReuse:

--- a/tests/test_nested_groups.py
+++ b/tests/test_nested_groups.py
@@ -476,6 +476,66 @@ class TestSameInstanceReuse:
             parser.parse_args([])
         assert "referenced more than once" in str(exc_info.value)
 
+    def test_three_link_cycle_raises(self):
+        """A → B → C → A. Synthetic — normal class syntax can't form
+        this because forward refs don't resolve at metaclass time —
+        but we manually wire __argument_groups__ to verify the
+        visited-set detector catches arbitrary cycles, not just
+        same-instance reuse on sibling attributes.
+        """
+        from types import MappingProxyType
+
+        class A(argclass.Group):
+            foo: int = 1
+
+        class B(argclass.Group):
+            foo: int = 2
+
+        class C(argclass.Group):
+            foo: int = 3
+
+        a, b, c = A(), B(), C()
+        A.__argument_groups__ = MappingProxyType({"b": b})
+        B.__argument_groups__ = MappingProxyType({"c": c})
+        C.__argument_groups__ = MappingProxyType({"a": a})
+
+        try:
+
+            class P(argclass.Parser):
+                root: A = a
+
+            parser = P()
+            with pytest.raises(ArgclassError) as exc_info:
+                parser.parse_args([])
+            assert "referenced more than once" in str(exc_info.value)
+            assert "root.b.c.a" in str(exc_info.value)
+        finally:
+            A.__argument_groups__ = MappingProxyType({})
+            B.__argument_groups__ = MappingProxyType({})
+            C.__argument_groups__ = MappingProxyType({})
+
+    def test_self_loop_raises(self):
+        """A group whose own __argument_groups__ contains itself."""
+        from types import MappingProxyType
+
+        class Loop(argclass.Group):
+            foo: int = 0
+
+        instance = Loop()
+        Loop.__argument_groups__ = MappingProxyType({"self": instance})
+
+        try:
+
+            class P(argclass.Parser):
+                root: Loop = instance
+
+            parser = P()
+            with pytest.raises(ArgclassError) as exc_info:
+                parser.parse_args([])
+            assert "referenced more than once" in str(exc_info.value)
+        finally:
+            Loop.__argument_groups__ = MappingProxyType({})
+
     def test_two_distinct_instances_of_same_class_ok(self):
         class Outer(argclass.Group):
             primary: Credentials = Credentials()

--- a/tests/test_nested_groups.py
+++ b/tests/test_nested_groups.py
@@ -14,7 +14,7 @@ import pytest
 
 import argclass
 from argclass.defaults import JSONDefaultsParser, TOMLDefaultsParser
-from argclass.exceptions import ArgclassError
+from argclass.exceptions import ArgclassError, ArgumentDefinitionError
 
 
 class Credentials(argclass.Group):
@@ -319,6 +319,104 @@ class TestHelp:
         out = capsys.readouterr().out
         assert "--endpoint-credentials-username" in out
         assert "endpoint.credentials" in out
+
+
+class TestGroupAnnotation:
+    """Annotated Group fields: auto-instantiate, reject Optional/None/etc."""
+
+    def test_annotation_only_auto_instantiates(self):
+        class G(argclass.Group):
+            foo: int = 0
+
+        class P(argclass.Parser):
+            g: G
+
+        parser = P()
+        parser.parse_args(["--g-foo=5"])
+        assert parser.g.foo == 5
+
+    def test_annotation_with_ellipsis_auto_instantiates(self):
+        class G(argclass.Group):
+            foo: int = 0
+
+        class P(argclass.Parser):
+            g: G = ...  # type: ignore[assignment]
+
+        parser = P()
+        parser.parse_args(["--g-foo=7"])
+        assert parser.g.foo == 7
+
+    def test_annotation_with_explicit_instance_works(self):
+        class G(argclass.Group):
+            foo: int = 0
+
+        class P(argclass.Parser):
+            g: G = G()
+
+        parser = P()
+        parser.parse_args(["--g-foo=3"])
+        assert parser.g.foo == 3
+
+    def test_optional_group_rejected(self):
+        class G(argclass.Group):
+            foo: int = 0
+
+        with pytest.raises(ArgumentDefinitionError) as exc_info:
+
+            class P(argclass.Parser):  # noqa: F841
+                g: G | None = None
+
+        assert "cannot be Optional" in str(exc_info.value)
+
+    def test_none_default_with_group_annotation_rejected(self):
+        class G(argclass.Group):
+            foo: int = 0
+
+        with pytest.raises(ArgumentDefinitionError) as exc_info:
+
+            class P(argclass.Parser):  # noqa: F841
+                g: G = None  # type: ignore[assignment]
+
+        assert "non-Group default" in str(exc_info.value)
+
+    def test_non_group_default_rejected(self):
+        class G(argclass.Group):
+            foo: int = 0
+
+        with pytest.raises(ArgumentDefinitionError) as exc_info:
+
+            class P(argclass.Parser):  # noqa: F841
+                g: G = "weird"  # type: ignore[assignment]
+
+        assert "non-Group default" in str(exc_info.value)
+
+    def test_incompatible_group_instance_rejected(self):
+        class G1(argclass.Group):
+            foo: int = 0
+
+        class G2(argclass.Group):
+            bar: int = 0
+
+        with pytest.raises(ArgumentDefinitionError) as exc_info:
+
+            class P(argclass.Parser):  # noqa: F841
+                g: G1 = G2()  # type: ignore[assignment]
+
+        assert "incompatible instance" in str(exc_info.value)
+
+    def test_annotated_nested_group_auto_instantiates(self):
+        class Inner(argclass.Group):
+            value: str = "default"
+
+        class Outer(argclass.Group):
+            inner: Inner
+
+        class P(argclass.Parser):
+            outer: Outer
+
+        parser = P()
+        parser.parse_args(["--outer-inner-value=set"])
+        assert parser.outer.inner.value == "set"
 
 
 class TestSameInstanceReuse:

--- a/tests/test_nested_groups.py
+++ b/tests/test_nested_groups.py
@@ -1,0 +1,356 @@
+"""Tests for nested argument groups (Parser -> Group -> Group -> ...).
+
+Covers CLI, environment variables, INI/JSON/TOML configs, help output,
+priority order, secrets, list-typed fields, and same-instance reuse
+detection.
+"""
+
+import os
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+import argclass
+from argclass.defaults import JSONDefaultsParser, TOMLDefaultsParser
+from argclass.exceptions import ArgclassError
+
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+    password: str = "secret"
+
+
+class Endpoint(argclass.Group):
+    host: str = "localhost"
+    port: int = 8080
+    credentials: Credentials = Credentials()
+
+
+class CLI(argclass.Parser):
+    debug: bool = False
+    endpoint: Endpoint = Endpoint()
+
+
+class TestCLI:
+    def test_defaults(self):
+        parser = CLI()
+        parser.parse_args([])
+        assert parser.debug is False
+        assert parser.endpoint.host == "localhost"
+        assert parser.endpoint.port == 8080
+        assert parser.endpoint.credentials.username == "admin"
+        assert parser.endpoint.credentials.password == "secret"
+
+    def test_override_all_levels(self):
+        parser = CLI()
+        parser.parse_args(
+            [
+                "--debug",
+                "--endpoint-host=10.0.0.1",
+                "--endpoint-port=9000",
+                "--endpoint-credentials-username=root",
+                "--endpoint-credentials-password=hunter2",
+            ],
+        )
+        assert parser.debug is True
+        assert parser.endpoint.host == "10.0.0.1"
+        assert parser.endpoint.port == 9000
+        assert parser.endpoint.credentials.username == "root"
+        assert parser.endpoint.credentials.password == "hunter2"
+
+    def test_three_level_nesting(self):
+        class TLS(argclass.Group):
+            cert: str = "/etc/cert"
+            key: str = "/etc/key"
+
+        class ConnectionSecurity(argclass.Group):
+            tls: TLS = TLS()
+            verify: bool = False
+
+        class Connection(argclass.Group):
+            host: str = "localhost"
+            security: ConnectionSecurity = ConnectionSecurity()
+
+        class App(argclass.Parser):
+            conn: Connection = Connection()
+
+        parser = App()
+        parser.parse_args(
+            [
+                "--conn-host=db.example.com",
+                "--conn-security-verify",
+                "--conn-security-tls-cert=/new/cert",
+            ],
+        )
+        assert parser.conn.host == "db.example.com"
+        assert parser.conn.security.verify is True
+        assert parser.conn.security.tls.cert == "/new/cert"
+        assert parser.conn.security.tls.key == "/etc/key"
+
+    def test_list_inside_nested_group(self):
+        class Tags(argclass.Group):
+            values: List[str] = argclass.Argument(
+                nargs=argclass.Nargs.ONE_OR_MORE,
+            )
+
+        class Resource(argclass.Group):
+            name: str = "thing"
+            tags: Tags = Tags()
+
+        class App(argclass.Parser):
+            resource: Resource = Resource()
+
+        parser = App()
+        parser.parse_args(
+            [
+                "--resource-tags-values",
+                "alpha",
+                "beta",
+                "gamma",
+            ],
+        )
+        assert parser.resource.tags.values == ["alpha", "beta", "gamma"]
+
+
+class TestPrefix:
+    def test_prefix_on_nested_group_overrides_cli_name(self):
+        class Inner(argclass.Group):
+            value: str = "default"
+
+        class Outer(argclass.Group):
+            inner: Inner = Inner(prefix="i")
+
+        class App(argclass.Parser):
+            outer: Outer = Outer()
+
+        parser = App()
+        parser.parse_args(["--outer-i-value=set"])
+        assert parser.outer.inner.value == "set"
+
+    def test_empty_prefix_on_nested_group_drops_segment(self):
+        class Inner(argclass.Group):
+            value: str = "default"
+
+        class Outer(argclass.Group):
+            inner: Inner = Inner(prefix="")
+
+        class App(argclass.Parser):
+            outer: Outer = Outer()
+
+        parser = App()
+        parser.parse_args(["--outer-value=set"])
+        assert parser.outer.inner.value == "set"
+
+
+class TestEnv:
+    def test_auto_env_var_prefix_nested(self):
+        env = {"APP_ENDPOINT_CREDENTIALS_USERNAME": "root_from_env"}
+        with patch.dict(os.environ, env, clear=False):
+            parser = CLI(auto_env_var_prefix="APP_")
+            parser.parse_args([])
+        assert parser.endpoint.credentials.username == "root_from_env"
+        assert parser.endpoint.credentials.password == "secret"
+
+    def test_explicit_env_var_in_nested_group(self):
+        class Inner(argclass.Group):
+            token: str = argclass.Argument(env_var="MY_TOKEN", default="")
+
+        class Outer(argclass.Group):
+            inner: Inner = Inner()
+
+        class App(argclass.Parser):
+            outer: Outer = Outer()
+
+        env = {"MY_TOKEN": "abc123"}
+        with patch.dict(os.environ, env, clear=False):
+            parser = App(auto_env_var_prefix="APP_")
+            parser.parse_args([])
+        assert parser.outer.inner.token == "abc123"
+
+
+class TestINI:
+    def test_nested_section(self, tmp_path: Path):
+        cfg = tmp_path / "config.ini"
+        cfg.write_text(
+            "[endpoint]\nhost = ini-host\nport = 9999\n"
+            "[endpoint.credentials]\nusername = ini-user\n"
+            "password = ini-pass\n",
+        )
+        parser = CLI(config_files=[cfg])
+        parser.parse_args([])
+        assert parser.endpoint.host == "ini-host"
+        assert parser.endpoint.port == 9999
+        assert parser.endpoint.credentials.username == "ini-user"
+        assert parser.endpoint.credentials.password == "ini-pass"
+
+    def test_missing_nested_section_falls_back_to_default(
+        self,
+        tmp_path: Path,
+    ):
+        cfg = tmp_path / "config.ini"
+        cfg.write_text("[endpoint]\nhost = only-host\n")
+        parser = CLI(config_files=[cfg])
+        parser.parse_args([])
+        assert parser.endpoint.host == "only-host"
+        assert parser.endpoint.credentials.username == "admin"
+
+    def test_three_level_ini(self, tmp_path: Path):
+        class TLS(argclass.Group):
+            cert: str = "/etc/cert"
+
+        class Sec(argclass.Group):
+            tls: TLS = TLS()
+
+        class Conn(argclass.Group):
+            sec: Sec = Sec()
+
+        class App(argclass.Parser):
+            conn: Conn = Conn()
+
+        cfg = tmp_path / "config.ini"
+        cfg.write_text("[conn.sec.tls]\ncert = /custom/cert\n")
+        parser = App(config_files=[cfg])
+        parser.parse_args([])
+        assert parser.conn.sec.tls.cert == "/custom/cert"
+
+
+class TestJSON:
+    def test_nested_dict(self, tmp_path: Path):
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            '{"endpoint": {"host": "json-host", '
+            '"credentials": {"username": "json-user", '
+            '"password": "json-pass"}}}',
+        )
+        parser = CLI(
+            config_files=[cfg],
+            config_parser_class=JSONDefaultsParser,
+        )
+        parser.parse_args([])
+        assert parser.endpoint.host == "json-host"
+        assert parser.endpoint.credentials.username == "json-user"
+        assert parser.endpoint.credentials.password == "json-pass"
+
+
+class TestTOML:
+    def test_nested_table(self, tmp_path: Path):
+        cfg = tmp_path / "config.toml"
+        cfg.write_text(
+            '[endpoint]\nhost = "toml-host"\n'
+            '[endpoint.credentials]\nusername = "toml-user"\n'
+            'password = "toml-pass"\n',
+        )
+        parser = CLI(
+            config_files=[cfg],
+            config_parser_class=TOMLDefaultsParser,
+        )
+        parser.parse_args([])
+        assert parser.endpoint.host == "toml-host"
+        assert parser.endpoint.credentials.username == "toml-user"
+        assert parser.endpoint.credentials.password == "toml-pass"
+
+
+class TestPriority:
+    def test_cli_beats_env_beats_config_beats_default(
+        self,
+        tmp_path: Path,
+    ):
+        cfg = tmp_path / "config.ini"
+        cfg.write_text(
+            "[endpoint.credentials]\nusername = from-config\n"
+            "password = from-config\n",
+        )
+
+        env = {
+            "APP_ENDPOINT_CREDENTIALS_USERNAME": "from-env",
+            "APP_ENDPOINT_CREDENTIALS_PASSWORD": "from-env",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            parser = CLI(
+                config_files=[cfg],
+                auto_env_var_prefix="APP_",
+            )
+            parser.parse_args(
+                ["--endpoint-credentials-username=from-cli"],
+            )
+        # CLI wins for username, env wins for password
+        assert parser.endpoint.credentials.username == "from-cli"
+        assert parser.endpoint.credentials.password == "from-env"
+
+    def test_config_beats_default_when_no_env_no_cli(
+        self,
+        tmp_path: Path,
+    ):
+        cfg = tmp_path / "config.ini"
+        cfg.write_text(
+            "[endpoint.credentials]\nusername = from-config\n",
+        )
+        parser = CLI(config_files=[cfg])
+        parser.parse_args([])
+        assert parser.endpoint.credentials.username == "from-config"
+        assert parser.endpoint.credentials.password == "secret"
+
+
+class TestSecret:
+    def test_secret_inside_nested_group(self):
+        class Auth(argclass.Group):
+            token: str = argclass.Secret()
+
+        class Outer(argclass.Group):
+            auth: Auth = Auth()
+
+        class App(argclass.Parser):
+            outer: Outer = Outer()
+
+        parser = App()
+        parser.parse_args(["--outer-auth-token=topsecret"])
+        # Stored value is the actual string under SecretString.
+        assert parser.outer.auth.token == "topsecret"
+        # SecretString masks itself in repr.
+        assert "topsecret" not in repr(parser.outer.auth.token)
+
+
+class TestHelp:
+    def test_help_contains_nested_arg_and_section(self, capsys):
+        parser = CLI()
+        parser.print_help()
+        out = capsys.readouterr().out
+        assert "--endpoint-credentials-username" in out
+        assert "endpoint.credentials" in out
+
+
+class TestSameInstanceReuse:
+    def test_reused_group_instance_raises(self):
+        shared = Credentials()
+
+        class Outer(argclass.Group):
+            primary: Credentials = shared
+            secondary: Credentials = shared
+
+        class App(argclass.Parser):
+            outer: Outer = Outer()
+
+        parser = App()
+        with pytest.raises(ArgclassError) as exc_info:
+            parser.parse_args([])
+        assert "referenced more than once" in str(exc_info.value)
+
+    def test_two_distinct_instances_of_same_class_ok(self):
+        class Outer(argclass.Group):
+            primary: Credentials = Credentials()
+            secondary: Credentials = Credentials()
+
+        class App(argclass.Parser):
+            outer: Outer = Outer()
+
+        parser = App()
+        parser.parse_args(
+            [
+                "--outer-primary-username=a",
+                "--outer-secondary-username=b",
+            ],
+        )
+        assert parser.outer.primary.username == "a"
+        assert parser.outer.secondary.username == "b"

--- a/tests/test_nested_groups.py
+++ b/tests/test_nested_groups.py
@@ -437,6 +437,75 @@ class TestGroupAnnotation:
         parser.parse_args(["--outer-inner-value=set"])
         assert parser.outer.inner.value == "set"
 
+    def test_group_in_complex_union_with_non_group_rejected(self):
+        """G | int (non-Optional union mixing Group with a regular
+        type) gets a Group-specific error message — not the generic
+        "use argclass.Argument with converter" hint, which would not
+        help the user understand the real problem."""
+
+        class G(argclass.Group):
+            foo: int = 0
+
+        with pytest.raises(ArgumentDefinitionError) as exc_info:
+            type(
+                "P",
+                (argclass.Parser,),
+                {"__annotations__": {"g": G | int}, "g": ...},
+            )
+
+        msg = str(exc_info.value)
+        assert "complex Union" in msg
+        assert "G" in msg
+
+    def test_union_of_two_group_classes_rejected(self):
+        """G1 | G2 is also rejected — only one Group class is
+        meaningful per attribute."""
+
+        class G1(argclass.Group):
+            foo: int = 0
+
+        class G2(argclass.Group):
+            bar: int = 0
+
+        with pytest.raises(ArgumentDefinitionError) as exc_info:
+            type(
+                "P",
+                (argclass.Parser,),
+                {"__annotations__": {"g": G1 | G2}, "g": ...},
+            )
+
+        assert "complex Union" in str(exc_info.value)
+
+    def test_three_member_union_with_group_and_none_rejected(self):
+        """G | int | None — three-member union containing a Group
+        also gets the Group-specific error."""
+
+        class G(argclass.Group):
+            foo: int = 0
+
+        with pytest.raises(ArgumentDefinitionError) as exc_info:
+            type(
+                "P",
+                (argclass.Parser,),
+                {"__annotations__": {"g": G | int | None}, "g": None},
+            )
+
+        assert "complex Union" in str(exc_info.value)
+
+    def test_non_group_complex_union_unaffected(self):
+        """int | str without explicit Argument still raises
+        ComplexTypeError (the pre-existing behaviour) — our new
+        Group-aware detection must not interfere with unrelated
+        Union annotations."""
+        from argclass.exceptions import ComplexTypeError
+
+        with pytest.raises(ComplexTypeError):
+            type(
+                "P",
+                (argclass.Parser,),
+                {"__annotations__": {"v": int | str}},
+            )
+
     def test_complex_union_annotation_does_not_break_group_detection(self):
         """Fields with unsupported Union types (e.g. int | str) must
         not raise during class definition just because we probe for

--- a/tests/test_nested_groups.py
+++ b/tests/test_nested_groups.py
@@ -553,3 +553,17 @@ class TestSameInstanceReuse:
         )
         assert parser.outer.primary.username == "a"
         assert parser.outer.secondary.username == "b"
+
+    def test_single_external_instance_bound_once_ok(self):
+        """An externally-created Group instance assigned to a single
+        attribute is fine. The reuse check only fires when the same
+        instance is bound to two or more attributes."""
+        shared = Credentials()
+
+        class P(argclass.Parser):
+            primary: Credentials = shared
+
+        parser = P()
+        parser.parse_args(["--primary-username=alice"])
+        assert parser.primary.username == "alice"
+        assert parser.primary is shared


### PR DESCRIPTION
This pull request introduces comprehensive support for **nested argument groups** in the `argclass` library, allowing groups to contain other groups at any depth. This feature is implemented in the core parser and thoroughly documented with examples for CLI, environment variables, and config files (INI/JSON/TOML). The changes also add robust error handling for group instance reuse and clarify the naming and sectioning rules for nested groups.

**Nested Groups Support**

* Added support for arbitrary nesting of `Group` fields within other `Group` classes in the core parser logic, including correct CLI, environment variable, and config file naming and sectioning. This includes recursive group traversal, attribute path-based naming, and config value resolution for nested groups. (`argclass/parser.py`, `argclass/defaults.py`) [[1]](diffhunk://#diff-9a62e2936b43864e76e5912a4ca4b14b56d5fa188e1c16f573666ef5428db934R611-R658) [[2]](diffhunk://#diff-9a62e2936b43864e76e5912a4ca4b14b56d5fa188e1c16f573666ef5428db934L629-R668) [[3]](diffhunk://#diff-9a62e2936b43864e76e5912a4ca4b14b56d5fa188e1c16f573666ef5428db934L638) [[4]](diffhunk://#diff-9a62e2936b43864e76e5912a4ca4b14b56d5fa188e1c16f573666ef5428db934L658) [[5]](diffhunk://#diff-9a62e2936b43864e76e5912a4ca4b14b56d5fa188e1c16f573666ef5428db934R715-R732) [[6]](diffhunk://#diff-48898348f7c1a3bfd289ab5da7315474aba86a01e7f3983643416c51ceb77f7aL103-R108) [[7]](diffhunk://#diff-48898348f7c1a3bfd289ab5da7315474aba86a01e7f3983643416c51ceb77f7aL112-R125)

* Implemented error detection for reusing the same `Group` instance in multiple attributes, raising `ArgclassError` with a helpful message. (`argclass/parser.py`)

**Documentation and Examples**

* Updated all major documentation files to explain and demonstrate nested groups, including new code examples for CLI, environment variables, and config files (INI/JSON/TOML). (`README.md`, `docs/groups.md`, `docs/environment.md`, `docs/config-files.md`, `CLAUDE.md`, `docs/index.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R92-R121) [[2]](diffhunk://#diff-ce3fd91438d1613c389915da67500215790d50ca4629d051ed66bc2bb87d3fbfR208-R336) [[3]](diffhunk://#diff-a9108d0ec764540686dfb76d3b842c82f218823c38cc29663eea636cd756c70fR100-R136) [[4]](diffhunk://#diff-7eb881aa4aa8a68edec173fd0c81bfbb45afbcfa4d083466f2f98f34342436a7R643-R720) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R67-R103) [[6]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L340-R342)

* Clarified how naming works for nested groups in all sources, and documented the effect (or lack thereof) of `prefix=` on config section names. [[1]](diffhunk://#diff-ce3fd91438d1613c389915da67500215790d50ca4629d051ed66bc2bb87d3fbfR208-R336) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R67-R103)

**Demo and Example Code Updates**

* Added and updated demo code in `argclass/__main__.py` to showcase nested groups, including new printouts and usage instructions. [[1]](diffhunk://#diff-afaa976b4bbc7a8950d76d89b7626711d83c262b10bead18a925d6daa619ba9eR86-R96) [[2]](diffhunk://#diff-afaa976b4bbc7a8950d76d89b7626711d83c262b10bead18a925d6daa619ba9eL195-R241) [[3]](diffhunk://#diff-afaa976b4bbc7a8950d76d89b7626711d83c262b10bead18a925d6daa619ba9eR252-R270)

**Internal Refactoring**

* Improved type hints, code structure, and error messages to support and clarify the nested group logic.

These changes make `argclass` significantly more powerful and flexible for complex configuration schemas, while ensuring predictable and intuitive behavior across all supported input sources.