### PR TITLE
Config file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,57 @@ del os.environ["APP_HOST"]
 del os.environ["APP_DEBUG"]
 ```
 
+### Generating Config Files
+
+argclass can WRITE config files for a parser — the inverse of
+reading them. Useful for scaffolding sample configs, dumping the
+running state, or exporting env-var listings.
+
+<!--- name: test_readme_config_gen --->
+```python
+import argclass
+
+class Database(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+
+class CLI(argclass.Parser):
+    debug: bool = False
+    db: Database = Database()
+
+parser = CLI()
+ini = argclass.INIConfigGenerator().dump_to_string(parser)
+assert "[DEFAULT]" in ini
+assert "[db]" in ini
+
+env = argclass.EnvConfigGenerator().dump_to_string(
+    CLI(auto_env_var_prefix="APP_"),
+)
+assert "APP_DEBUG=false" in env
+assert "APP_DB_HOST=localhost" in env
+```
+
+Ship a `--generate-config FILE` flag with the built-in action
+(supply `-` for stdout):
+
+```python
+import argclass
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    generate = argclass.Argument(
+        "--generate-config",
+        action=argclass.GenerateConfigAction,
+        generator=argclass.TOMLConfigGenerator,
+    )
+```
+
+Four built-in generators: `INIConfigGenerator`,
+`JSONConfigGenerator`, `TOMLConfigGenerator`, `EnvConfigGenerator`.
+Subclass `ConfigGenerator` for custom formats. See [Generating
+Config Files](https://docs.argclass.com/config-generation.html)
+for the full guide.
+
 ### Subcommands
 
 ```python

--- a/argclass/__init__.py
+++ b/argclass/__init__.py
@@ -22,6 +22,7 @@ from .defaults import (
     ValueKind,
 )
 from .emit import (
+    ConfigField,
     ConfigGenerator,
     EnvConfigGenerator,
     GenerateConfigAction,
@@ -124,8 +125,10 @@ __all__ = [
     "UnexpectedConfigValue",
     # Config generators (write configs from a parser).
     # ``ConfigGenerator`` is exposed for typing / subclassing;
-    # ``NonConfigAction`` lets user-defined actions opt out of
-    # dumps. Other helpers stay in ``argclass.emit``.
+    # ``ConfigField`` is the record type custom ``render`` impls
+    # consume; ``NonConfigAction`` lets user-defined actions opt
+    # out of dumps. Other helpers stay in ``argclass.emit``.
+    "ConfigField",
     "ConfigGenerator",
     "INIConfigGenerator",
     "JSONConfigGenerator",

--- a/argclass/__init__.py
+++ b/argclass/__init__.py
@@ -122,7 +122,10 @@ __all__ = [
     "TOMLDefaultsParser",
     "ValueKind",
     "UnexpectedConfigValue",
-    # Config generators (write configs from a parser)
+    # Config generators (write configs from a parser).
+    # ``ConfigGenerator`` is exposed for typing / subclassing;
+    # ``NonConfigAction`` lets user-defined actions opt out of
+    # dumps. Other helpers stay in ``argclass.emit``.
     "ConfigGenerator",
     "INIConfigGenerator",
     "JSONConfigGenerator",

--- a/argclass/__init__.py
+++ b/argclass/__init__.py
@@ -21,6 +21,15 @@ from .defaults import (
     UnexpectedConfigValue,
     ValueKind,
 )
+from .emit import (
+    ConfigGenerator,
+    EnvConfigGenerator,
+    GenerateConfigAction,
+    INIConfigGenerator,
+    JSONConfigGenerator,
+    NonConfigAction,
+    TOMLConfigGenerator,
+)
 from .exceptions import (
     ArgclassError,
     ArgumentDefinitionError,
@@ -113,6 +122,14 @@ __all__ = [
     "TOMLDefaultsParser",
     "ValueKind",
     "UnexpectedConfigValue",
+    # Config generators (write configs from a parser)
+    "ConfigGenerator",
+    "INIConfigGenerator",
+    "JSONConfigGenerator",
+    "TOMLConfigGenerator",
+    "EnvConfigGenerator",
+    "GenerateConfigAction",
+    "NonConfigAction",
     # Factory functions
     "Argument",
     "ArgumentSingle",

--- a/argclass/__main__.py
+++ b/argclass/__main__.py
@@ -57,6 +57,8 @@ Examples:
   %(prog)s secrets --api-key my-secret
   DEMO_HOST=example.com %(prog)s env
   %(prog)s subcommands hello --user Alice
+  %(prog)s genconfig --generate-ini -
+  %(prog)s genconfig --generate-toml /tmp/myapp.toml
 """
 
 
@@ -440,6 +442,104 @@ class SubcommandDemo(argclass.Parser):
         return 1
 
 
+# -- Subcommand: generate-config ---------------------------------
+
+
+class GenerateConfigDemo(argclass.Parser):
+    """Demonstrates argclass.GenerateConfigAction in every format.
+
+    Four flags, one Action class, one Generator class per format:
+
+      class CLI(argclass.Parser):
+          ini  = argclass.Argument(
+              "--generate-ini",
+              action=argclass.GenerateConfigAction,
+              generator=argclass.INIConfigGenerator,
+          )
+          toml = argclass.Argument(
+              "--generate-toml",
+              action=argclass.GenerateConfigAction,
+              generator=argclass.TOMLConfigGenerator,
+          )
+          # ... and so on for JSON and ENV
+
+    Each flag takes a FILE (or "-" for stdout), writes the rendered
+    config, and exits. The actions inherit NonConfigAction, so they
+    never appear in the generated output themselves.
+
+    Try:
+      %(prog)s genconfig --generate-ini -
+      %(prog)s genconfig --generate-toml /tmp/argclass-demo.toml
+      %(prog)s genconfig --generate-json -
+      DEMO_HOST=h %(prog)s genconfig --generate-env -
+    """
+
+    # Demo state that ends up in the generated config.
+    host: str = argclass.Argument(
+        default="localhost",
+        env_var="DEMO_HOST",
+        help="Server host",
+    )
+    port: int = argclass.Argument(default=8080, help="Server port")
+    debug: bool = argclass.Argument(default=False, help="Debug mode")
+    tags: list[str] = argclass.Argument(
+        nargs=argclass.Nargs.ZERO_OR_MORE,
+        default=["alpha", "beta"],
+        help="Free-form tags",
+    )
+
+    # Nested group — verifies dotted sections in INI/TOML and nested
+    # objects in JSON/.env.
+    server: ServerGroup = ServerGroup(title="Server options")
+
+    # Four flags, one per format. The Action exits after writing, so
+    # only one of these can be invoked per run.
+    generate_ini = argclass.Argument(
+        "--generate-ini",
+        action=argclass.GenerateConfigAction,
+        generator=argclass.INIConfigGenerator,
+        help="Write INI to FILE (use - for stdout)",
+    )
+    generate_toml = argclass.Argument(
+        "--generate-toml",
+        action=argclass.GenerateConfigAction,
+        generator=argclass.TOMLConfigGenerator,
+        help="Write TOML to FILE (use - for stdout)",
+    )
+    generate_json = argclass.Argument(
+        "--generate-json",
+        action=argclass.GenerateConfigAction,
+        generator=argclass.JSONConfigGenerator,
+        help="Write JSON to FILE (use - for stdout)",
+    )
+    generate_env = argclass.Argument(
+        "--generate-env",
+        action=argclass.GenerateConfigAction,
+        generator=argclass.EnvConfigGenerator,
+        help="Write .env to FILE (use - for stdout)",
+    )
+
+    def __call__(self) -> int:
+        # The Action subclasses exit on use, so reaching __call__
+        # means the user invoked the subcommand without any
+        # --generate-* flag. Show source + help.
+        print_source(ServerGroup, self)
+        print("== Config Generation ==\n")
+        print(
+            "Pick a format flag and a destination ('-' for stdout):",
+        )
+        print()
+        print("  --generate-ini  FILE   →  INIConfigGenerator")
+        print("  --generate-toml FILE   →  TOMLConfigGenerator")
+        print("  --generate-json FILE   →  JSONConfigGenerator")
+        print("  --generate-env  FILE   →  EnvConfigGenerator")
+        print()
+        print("Tip: try setting DEMO_HOST=... and rerunning")
+        print("--generate-env - to see env-resolved values land in")
+        print("the output.")
+        return 0
+
+
 # -- Top-level parser --------------------------------------------
 
 
@@ -453,6 +553,7 @@ class DemoParser(argclass.Parser):
     secrets = SecretsDemo()
     env = EnvDemo()
     subcommands = SubcommandDemo()
+    genconfig = GenerateConfigDemo(auto_env_var_prefix="DEMO_")
 
     def __call__(self) -> int:
         result = super().__call__()

--- a/argclass/defaults.py
+++ b/argclass/defaults.py
@@ -191,15 +191,8 @@ class INIDefaultsParser(AbstractDefaultsParser):
         result: Dict[str, Any] = dict(
             parser.items(parser.default_section, raw=True),
         )
-
-        # configparser auto-cascades [DEFAULT] keys into every other
-        # section. argclass groups are independent argument
-        # namespaces — they share nothing with top-level args — so
-        # we collect each section's OWN keys only. Without this, a
-        # top-level ``host = root`` would leak into ``[inner]`` and
-        # override an Optional[str] = None group default on reload.
         for section in parser.sections():
-            result[section] = dict(parser._sections[section])  # type: ignore[attr-defined]
+            result[section] = own_section_items(parser, section)
 
         self._values = result
         return result
@@ -219,6 +212,29 @@ class INIDefaultsParser(AbstractDefaultsParser):
             return value.lower() in self.BOOL_TRUE_VALUES
 
         return value
+
+
+def own_section_items(
+    parser: configparser.ConfigParser,
+    section: str,
+) -> Dict[str, str]:
+    """Return ``section``'s own keys, excluding cascaded ``[DEFAULT]``.
+
+    configparser's public API
+    (``parser.items(section, raw=True)`` / ``parser[section]``)
+    inherits keys from ``[DEFAULT]`` into every section. argclass
+    groups are independent argument namespaces — a top-level
+    ``host = root`` must not leak into ``[inner].host`` when the
+    group's own default is ``None``.
+
+    There's no documented opt-out, so this helper isolates the
+    one place where we reach into ``parser._sections``. Keeps the
+    private-attribute risk to a single well-commented call site.
+    """
+    own: Dict[str, str] = dict(
+        parser._sections[section],  # type: ignore[attr-defined]
+    )
+    return own
 
 
 class JSONDefaultsParser(AbstractDefaultsParser):

--- a/argclass/defaults.py
+++ b/argclass/defaults.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Tuple, Union
 
 from .exceptions import ConfigurationError
+from .utils import own_section_items
 
 try:
     import tomllib
@@ -212,29 +213,6 @@ class INIDefaultsParser(AbstractDefaultsParser):
             return value.lower() in self.BOOL_TRUE_VALUES
 
         return value
-
-
-def own_section_items(
-    parser: configparser.ConfigParser,
-    section: str,
-) -> Dict[str, str]:
-    """Return ``section``'s own keys, excluding cascaded ``[DEFAULT]``.
-
-    configparser's public API
-    (``parser.items(section, raw=True)`` / ``parser[section]``)
-    inherits keys from ``[DEFAULT]`` into every section. argclass
-    groups are independent argument namespaces — a top-level
-    ``host = root`` must not leak into ``[inner].host`` when the
-    group's own default is ``None``.
-
-    There's no documented opt-out, so this helper isolates the
-    one place where we reach into ``parser._sections``. Keeps the
-    private-attribute risk to a single well-commented call site.
-    """
-    own: Dict[str, str] = dict(
-        parser._sections[section],  # type: ignore[attr-defined]
-    )
-    return own
 
 
 class JSONDefaultsParser(AbstractDefaultsParser):

--- a/argclass/defaults.py
+++ b/argclass/defaults.py
@@ -192,8 +192,14 @@ class INIDefaultsParser(AbstractDefaultsParser):
             parser.items(parser.default_section, raw=True),
         )
 
+        # configparser auto-cascades [DEFAULT] keys into every other
+        # section. argclass groups are independent argument
+        # namespaces — they share nothing with top-level args — so
+        # we collect each section's OWN keys only. Without this, a
+        # top-level ``host = root`` would leak into ``[inner]`` and
+        # override an Optional[str] = None group default on reload.
         for section in parser.sections():
-            result[section] = dict(parser.items(section, raw=True))
+            result[section] = dict(parser._sections[section])  # type: ignore[attr-defined]
 
         self._values = result
         return result

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -34,6 +34,7 @@ import os
 import sys
 from typing import Any, Dict, IO, List, Optional, Tuple, Union, cast
 
+from .parser import get_argclass_parser
 from .store import AbstractGroup, AbstractParser, TypedArgument
 from .types import Actions
 
@@ -659,7 +660,8 @@ class GenerateConfigAction(NonConfigAction):
         values: Any,
         option_string: Optional[str] = None,
     ) -> None:
-        argclass_parser = getattr(parser, "argclass_parser", None)
+        # Out-of-band back-reference avoids touching argparse_parser.
+        argclass_parser = get_argclass_parser(parser)
         if argclass_parser is None:
             parser.error(
                 "argclass parser back-reference missing — "

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -407,6 +407,8 @@ class INIConfigGenerator(ConfigGenerator):
         if root:
             lines.append("[DEFAULT]")
             for key, value in root.items():
+                if value is None:
+                    continue
                 if text := help_map.get((key,)):
                     lines.append(f"; {text}")
                 lines.append(f"{key} = {self.render_scalar(value)}")
@@ -415,6 +417,8 @@ class INIConfigGenerator(ConfigGenerator):
             section_path = tuple(section_name.split("."))
             lines.append(f"[{section_name}]")
             for key, value in items.items():
+                if value is None:
+                    continue
                 if text := help_map.get(section_path + (key,)):
                     lines.append(f"; {text}")
                 lines.append(f"{key} = {self.render_scalar(value)}")
@@ -423,8 +427,6 @@ class INIConfigGenerator(ConfigGenerator):
 
     @staticmethod
     def render_scalar(value: Any) -> str:
-        if value is None:
-            return ""
         if isinstance(value, bool):
             return "true" if value else "false"
         if isinstance(value, (list, tuple)):

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -1,11 +1,12 @@
-"""Config-file generators: render an argclass Parser to INI/JSON/TOML.
+"""Config-file generators: render an argclass Parser to INI/JSON/TOML/.env.
 
 Symmetric counterpart to ``argclass/defaults.py`` (which READS configs).
-Generators walk the parser tree (mirroring the recursion used by
-``Parser._fill_group``), produce a nested dict, and render it.
+The parser tree is walked once, yielding :class:`ConfigField` records;
+generators consume that iterator and produce a format-specific string.
 
-Subclass ``ConfigGenerator`` and override ``render`` to add a new
-format. The walking + Action wiring are shared.
+Subclass :class:`ConfigGenerator` and override :meth:`render` to add a
+new format. The walking + Action wiring are shared — your subclass only
+decides how to turn a stream of fields into text.
 
 Usage::
 
@@ -32,7 +33,21 @@ import argparse
 import json
 import os
 import sys
-from typing import Any, Dict, IO, List, Optional, Tuple, Union, cast
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path, PurePath
+from typing import (
+    Any,
+    Dict,
+    IO,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from .parser import get_argclass_parser
 from .store import AbstractGroup, AbstractParser, TypedArgument
@@ -68,9 +83,6 @@ def should_emit(argument: TypedArgument) -> bool:
     action = argument.action
     if isinstance(action, type):
         return bool(getattr(action, "__emit_config__", True))
-    # Actions enum members compare equal to their string values, so
-    # one membership test covers both Actions.HELP / Actions.VERSION
-    # and the raw "help" / "version" strings argparse accepts.
     if action in (Actions.VERSION, Actions.HELP):
         return False
     return True
@@ -121,10 +133,6 @@ def current_value(
     return argument.default
 
 
-HelpMap = Dict[Tuple[str, ...], str]
-EnvMap = Dict[Tuple[str, ...], str]
-
-
 def derive_env_var(
     auto_prefix: Optional[str],
     dest: str,
@@ -150,183 +158,213 @@ def group_cli_segment(group: AbstractGroup, attr_name: str) -> str:
     return prefix if prefix is not None else attr_name
 
 
+def normalize_value(value: Any) -> Any:
+    """Convert non-config-native types to round-trippable forms.
+
+    - ``Enum`` / ``IntEnum`` → ``.name`` (matches ``EnumArgument``
+      which accepts member names).
+    - ``set`` / ``frozenset`` → ``list`` (sorted when comparable, so
+      output stays stable).
+    - ``Path`` → ``str``.
+
+    Already-native types (``str``/``int``/``float``/``bool``/``list``/
+    ``tuple``/``None``) pass through. ``SecretString`` passes through
+    too since it subclasses ``str``.
+    """
+    if isinstance(value, Enum):
+        return value.name
+    if isinstance(value, (set, frozenset)):
+        try:
+            return sorted(value)
+        except TypeError:
+            return list(value)
+    if isinstance(value, PurePath):
+        return str(value)
+    return value
+
+
+@dataclass(frozen=True)
+class ConfigField:
+    """A single leaf argument from the parser tree, ready to emit.
+
+    A generator iterates these and writes them in the target format.
+    Sections are derived from ``attr_path[:-1]``; the field key is
+    ``attr_path[-1]``.
+
+    Attributes
+    ----------
+    attr_path:
+        Tuple of attribute names from the parser root down to the
+        leaf (``("endpoint", "credentials", "username")``). The last
+        element is the field name; everything before it forms the
+        section path used by INI / TOML.
+    cli_path:
+        Same shape as ``attr_path`` but respecting per-group
+        ``prefix=`` overrides — useful when reconstructing CLI flag
+        names.
+    dest:
+        argparse ``dest`` for the field
+        (``"endpoint_credentials_username"``). Joins ``cli_path``
+        with underscores.
+    argument:
+        The owning :class:`TypedArgument`. Carries declared type,
+        help, env_var, etc.
+    target:
+        The Parser or Group instance that owns this attribute. Lets
+        renderers reach back into the source if needed.
+    value:
+        The resolved value, already :func:`normalize_value`-d so it
+        round-trips through every supported format.
+    env_var:
+        Env var name argclass would read (explicit ``env_var=`` or
+        derived from ``auto_env_var_prefix=``). ``None`` when no env
+        var is configured.
+    help:
+        Help text declared on the argument, or ``None``.
+    """
+
+    attr_path: Tuple[str, ...]
+    cli_path: Tuple[str, ...]
+    dest: str
+    argument: TypedArgument
+    target: Any
+    value: Any
+    env_var: Optional[str]
+    help: Optional[str]
+
+    @property
+    def section_path(self) -> Tuple[str, ...]:
+        """Path to the enclosing section, derived from ``attr_path``."""
+        return self.attr_path[:-1]
+
+    @property
+    def key(self) -> str:
+        """Bare leaf attribute name."""
+        return self.attr_path[-1]
+
+
+def iter_config_fields(
+    parser: AbstractParser,
+    *,
+    namespace: Optional[argparse.Namespace] = None,
+) -> Iterator[ConfigField]:
+    """Walk ``parser`` and yield one :class:`ConfigField` per leaf.
+
+    Subparsers are skipped (they're runtime branches, not config
+    state). Non-emittable arguments (``--help``, ``--version``, any
+    :class:`NonConfigAction` subclass) are filtered out by
+    :func:`should_emit`.
+
+    ``namespace``, when provided, lets fields pick up CLI args that
+    argparse has already parsed — used by
+    :class:`GenerateConfigAction` mid-parse.
+    """
+    auto_prefix = getattr(parser, "_auto_env_var_prefix", None)
+    yield from iter_subtree_fields(
+        parser,
+        attr_path=(),
+        cli_path=(),
+        auto_prefix=auto_prefix,
+        namespace=namespace,
+    )
+
+
+def iter_subtree_fields(
+    target: Any,
+    *,
+    attr_path: Tuple[str, ...] = (),
+    cli_path: Tuple[str, ...] = (),
+    auto_prefix: Optional[str] = None,
+    namespace: Optional[argparse.Namespace] = None,
+) -> Iterator[ConfigField]:
+    """Recursive walker used by :func:`iter_config_fields`.
+
+    Power-users can call this directly to walk a sub-tree (for example
+    to dump just one nested group). Pass the cumulative ``attr_path``
+    and ``cli_path`` you want the yielded fields to carry.
+    """
+    node = cast(Any, target)
+    cli_prefix = "_".join(cli_path)
+    for name, argument in node.__arguments__.items():
+        if not should_emit(argument):
+            continue
+        dest = f"{cli_prefix}_{name}" if cli_prefix else name
+        env_var = derive_env_var(auto_prefix, dest, argument)
+        raw = current_value(
+            target,
+            name,
+            argument,
+            namespace=namespace,
+            dest=dest,
+            env_var=env_var,
+        )
+        yield ConfigField(
+            attr_path=attr_path + (name,),
+            cli_path=cli_path + (name,),
+            dest=dest,
+            argument=argument,
+            target=target,
+            value=normalize_value(raw),
+            env_var=env_var,
+            help=argument.help if argument.help else None,
+        )
+    for group_name, group in node.__argument_groups__.items():
+        seg = group_cli_segment(group, group_name)
+        child_cli = cli_path + ((seg,) if seg else ())
+        yield from iter_subtree_fields(
+            group,
+            attr_path=attr_path + (group_name,),
+            cli_path=child_cli,
+            auto_prefix=auto_prefix,
+            namespace=namespace,
+        )
+
+
+def fields_to_nested_dict(
+    fields: Iterable[ConfigField],
+    *,
+    skip_none: bool = False,
+) -> Dict[str, Any]:
+    """Build a nested dict from a stream of :class:`ConfigField`.
+
+    Used by :class:`JSONConfigGenerator`. Each section path becomes a
+    nested dict layer; the leaf attribute is set to ``field.value``.
+    When ``skip_none`` is true, ``None`` values are omitted entirely
+    so reloading falls back to the argument's own default.
+    """
+    out: Dict[str, Any] = {}
+    for field in fields:
+        if skip_none and field.value is None:
+            continue
+        target = out
+        for segment in field.section_path:
+            sub = target.get(segment)
+            if not isinstance(sub, dict):
+                sub = {}
+                target[segment] = sub
+            target = sub
+        target[field.key] = field.value
+    return out
+
+
 class ConfigGenerator:
     """Walks an argclass Parser and renders its state to a config
-    string. Subclass and override :meth:`render` for a new format.
+    string.
 
-    The walking + Action wiring live here; subclasses only need to
-    implement ``render(data, help_map) -> str``.
+    Subclasses override :meth:`render`. The base
+    :meth:`dump_to_string` and :meth:`dump` methods take care of
+    walking the parser and writing to disk / stdout / a file object.
     """
 
     #: File extension hint. Subclasses set this.
     extension: str = ""
 
-    def build_dict(
-        self,
-        parser: AbstractParser,
-        *,
-        namespace: Optional[argparse.Namespace] = None,
-    ) -> Dict[str, Any]:
-        """Walk the parser, return a nested dict mirroring its tree.
+    def render(self, fields: Iterable[ConfigField]) -> str:
+        """Render a stream of :class:`ConfigField` records to text.
 
-        Top-level arguments become root keys; each group becomes a
-        nested dict under its attribute name. Subparsers are skipped
-        (they represent runtime branches, not config-time state).
-
-        When ``namespace`` is provided, values are read from it (and
-        from ``os.environ`` for args with env vars) — used by
-        :class:`GenerateConfigAction` so the dump reflects CLI flags
-        and env vars even when triggered mid-parse.
+        Override this for a new format. Default implementation just
+        raises — every format has to decide how to lay out fields.
         """
-        node = cast(Any, parser)
-        auto_prefix = getattr(parser, "_auto_env_var_prefix", None)
-        result: Dict[str, Any] = {}
-        for name, argument in node.__arguments__.items():
-            if not should_emit(argument):
-                continue
-            env = derive_env_var(auto_prefix, name, argument)
-            result[name] = current_value(
-                parser,
-                name,
-                argument,
-                namespace=namespace,
-                dest=name,
-                env_var=env,
-            )
-        for group_name, group in node.__argument_groups__.items():
-            seg = group_cli_segment(group, group_name)
-            cli_path = (seg,) if seg else ()
-            result[group_name] = self.build_group_dict(
-                group,
-                cli_path=cli_path,
-                auto_prefix=auto_prefix,
-                namespace=namespace,
-            )
-        return result
-
-    def build_group_dict(
-        self,
-        group: AbstractGroup,
-        *,
-        cli_path: Tuple[str, ...] = (),
-        auto_prefix: Optional[str] = None,
-        namespace: Optional[argparse.Namespace] = None,
-    ) -> Dict[str, Any]:
-        node = cast(Any, group)
-        cli_prefix = "_".join(cli_path)
-        out: Dict[str, Any] = {}
-        for name, argument in node.__arguments__.items():
-            if not should_emit(argument):
-                continue
-            dest = f"{cli_prefix}_{name}" if cli_prefix else name
-            env = derive_env_var(auto_prefix, dest, argument)
-            out[name] = current_value(
-                group,
-                name,
-                argument,
-                namespace=namespace,
-                dest=dest,
-                env_var=env,
-            )
-        for child_name, child_group in node.__argument_groups__.items():
-            seg = group_cli_segment(child_group, child_name)
-            child_cli = cli_path + ((seg,) if seg else ())
-            out[child_name] = self.build_group_dict(
-                child_group,
-                cli_path=child_cli,
-                auto_prefix=auto_prefix,
-                namespace=namespace,
-            )
-        return out
-
-    def build_help_map(self, parser: AbstractParser) -> HelpMap:
-        """Return ``{path: help_text}`` for every leaf argument with
-        a help string. ``path`` is the tuple of attribute names from
-        the parser root down to the leaf."""
-        node = cast(Any, parser)
-        out: HelpMap = {}
-        for name, argument in node.__arguments__.items():
-            if argument.help and should_emit(argument):
-                out[(name,)] = argument.help
-        for group_name, group in node.__argument_groups__.items():
-            self.collect_group_help(group, (group_name,), out)
-        return out
-
-    def collect_group_help(
-        self,
-        group: AbstractGroup,
-        prefix: Tuple[str, ...],
-        out: HelpMap,
-    ) -> None:
-        node = cast(Any, group)
-        for name, argument in node.__arguments__.items():
-            if argument.help and should_emit(argument):
-                out[prefix + (name,)] = argument.help
-        for child_name, child in node.__argument_groups__.items():
-            self.collect_group_help(child, prefix + (child_name,), out)
-
-    def build_env_map(self, parser: AbstractParser) -> EnvMap:
-        """Return ``{path: env_var_name}`` for every leaf argument
-        that has an env var — either an explicit one on the argument
-        or one derived from the parser's ``auto_env_var_prefix``.
-
-        Arguments without a resolvable env var are omitted.
-        """
-        node = cast(Any, parser)
-        auto_prefix = getattr(parser, "_auto_env_var_prefix", None)
-        out: EnvMap = {}
-        for name, argument in node.__arguments__.items():
-            if not should_emit(argument):
-                continue
-            env = derive_env_var(auto_prefix, name, argument)
-            if env:
-                out[(name,)] = env
-        for group_name, group in node.__argument_groups__.items():
-            seg = group_cli_segment(group, group_name)
-            cli_path = (seg,) if seg else ()
-            self.collect_group_env(
-                group,
-                (group_name,),
-                cli_path,
-                auto_prefix,
-                out,
-            )
-        return out
-
-    def collect_group_env(
-        self,
-        group: AbstractGroup,
-        attr_path: Tuple[str, ...],
-        cli_path: Tuple[str, ...],
-        auto_prefix: Optional[str],
-        out: EnvMap,
-    ) -> None:
-        node = cast(Any, group)
-        cli_prefix = "_".join(cli_path)
-        for name, argument in node.__arguments__.items():
-            if not should_emit(argument):
-                continue
-            dest = f"{cli_prefix}_{name}" if cli_prefix else name
-            env = derive_env_var(auto_prefix, dest, argument)
-            if env:
-                out[attr_path + (name,)] = env
-        for child_name, child in node.__argument_groups__.items():
-            seg = group_cli_segment(child, child_name)
-            child_cli = cli_path + ((seg,) if seg else ())
-            self.collect_group_env(
-                child,
-                attr_path + (child_name,),
-                child_cli,
-                auto_prefix,
-                out,
-            )
-
-    def render(
-        self,
-        data: Dict[str, Any],
-        help_map: Optional[HelpMap] = None,
-    ) -> str:
-        """Render the dict to a config-format string. Override me."""
         raise NotImplementedError
 
     def dump_to_string(
@@ -335,96 +373,93 @@ class ConfigGenerator:
         *,
         namespace: Optional[argparse.Namespace] = None,
     ) -> str:
-        """Convenience: build_dict + render in one call."""
+        """Walk ``parser`` and return the rendered config as a
+        string."""
         return self.render(
-            self.build_dict(parser, namespace=namespace),
-            self.build_help_map(parser),
+            iter_config_fields(parser, namespace=namespace),
         )
 
     def dump(
         self,
         parser: AbstractParser,
-        dest: Union[str, IO[str]],
+        dest: Union[str, Path, IO[str]],
         *,
         namespace: Optional[argparse.Namespace] = None,
     ) -> None:
         """Write the rendered config to ``dest``.
 
-        ``dest`` may be a path, a file-like object, or the string
-        ``"-"`` (writes to stdout).
+        ``dest`` may be a filesystem path (as ``str`` or
+        :class:`pathlib.Path`), a file-like object, or the string
+        ``"-"`` for stdout.
         """
         content = self.dump_to_string(parser, namespace=namespace)
         if dest == "-":
             sys.stdout.write(content)
-        elif isinstance(dest, str):
+            return
+        if isinstance(dest, (str, Path)):
             with open(dest, "w") as fp:
                 fp.write(content)
-        else:
-            dest.write(content)
+            return
+        dest.write(content)
 
 
-def flatten_sections(
-    path: Tuple[str, ...],
-    value: Dict[str, Any],
-    sections: Dict[str, Dict[str, Any]],
-) -> None:
-    """Recursively flatten nested-dict groups into dotted section names.
+def group_fields_by_section(
+    fields: Iterable[ConfigField],
+) -> "Dict[Tuple[str, ...], List[ConfigField]]":
+    """Group a stream of fields by ``section_path``.
 
-    Shared helper for INI and TOML emitters, which both use
-    ``[parent.child]`` style section headers.
+    Preserves the original order both for sections and for fields
+    within each section.
     """
-    section_name = ".".join(path)
-    scalars: Dict[str, Any] = {}
-    for k, v in value.items():
-        if isinstance(v, dict):
-            flatten_sections(path + (k,), v, sections)
-        else:
-            scalars[k] = v
-    sections[section_name] = scalars
+    sections: Dict[Tuple[str, ...], List[ConfigField]] = {}
+    for field in fields:
+        sections.setdefault(field.section_path, []).append(field)
+    return sections
 
 
 class INIConfigGenerator(ConfigGenerator):
-    """Render a parser to INI. Help text is emitted as ``; <text>``
-    comments above each key. Nested groups use dotted section names
-    (``[parent.child]``)."""
+    """Render a parser to INI.
+
+    Top-level arguments go under ``[DEFAULT]`` (read by
+    :class:`argclass.INIDefaultsParser`); nested groups become dotted
+    sections (``[endpoint.credentials]``). Help text is emitted as
+    ``; <text>`` comments above each key.
+
+    Caveat: configparser's ``[DEFAULT]`` section cascades into every
+    other section. If a top-level argument shares a name with a group
+    attribute, the top-level value will be inherited by the group on
+    reload. Rename one of the colliding attributes to avoid this.
+    """
 
     extension = ".ini"
 
-    def render(
-        self,
-        data: Dict[str, Any],
-        help_map: Optional[HelpMap] = None,
-    ) -> str:
-        help_map = help_map or {}
-        root: Dict[str, Any] = {}
-        sections: Dict[str, Dict[str, Any]] = {}
-        for key, value in data.items():
-            if isinstance(value, dict):
-                flatten_sections((key,), value, sections)
-            else:
-                root[key] = value
-
+    def render(self, fields: Iterable[ConfigField]) -> str:
+        sections = group_fields_by_section(fields)
         lines: List[str] = []
-        if root:
+        root_fields = sections.pop((), [])
+        if root_fields:
             lines.append("[DEFAULT]")
-            for key, value in root.items():
-                if value is None:
-                    continue
-                if text := help_map.get((key,)):
-                    lines.append(f"; {text}")
-                lines.append(f"{key} = {self.render_scalar(value)}")
+            self._emit_fields(root_fields, lines)
             lines.append("")
-        for section_name, items in sections.items():
-            section_path = tuple(section_name.split("."))
-            lines.append(f"[{section_name}]")
-            for key, value in items.items():
-                if value is None:
-                    continue
-                if text := help_map.get(section_path + (key,)):
-                    lines.append(f"; {text}")
-                lines.append(f"{key} = {self.render_scalar(value)}")
+        for path, items in sections.items():
+            lines.append(f"[{'.'.join(path)}]")
+            self._emit_fields(items, lines)
             lines.append("")
         return "\n".join(lines)
+
+    def _emit_fields(
+        self,
+        fields: List[ConfigField],
+        lines: List[str],
+    ) -> None:
+        for field in fields:
+            if field.value is None:
+                # configparser has no native None; dropping the key
+                # lets the reloaded parser fall back to its default.
+                continue
+            if field.help:
+                lines.append(f"; {field.help}")
+            lines.append(f"{field.key} = {self.render_scalar(field.value)}")
 
     @staticmethod
     def render_scalar(value: Any) -> str:
@@ -436,20 +471,17 @@ class INIConfigGenerator(ConfigGenerator):
 
 
 class JSONConfigGenerator(ConfigGenerator):
-    """Render a parser to JSON. Comments are not supported by JSON,
-    so help text is dropped. Nested groups become nested objects."""
+    """Render a parser to JSON.
+
+    Comments are not supported by JSON, so help text is dropped.
+    Nested groups become nested objects.
+    """
 
     extension = ".json"
 
-    def render(
-        self,
-        data: Dict[str, Any],
-        help_map: Optional[HelpMap] = None,
-    ) -> str:
-        return (
-            json.dumps(self.coerce_value(data), indent=2, sort_keys=False)
-            + "\n"
-        )
+    def render(self, fields: Iterable[ConfigField]) -> str:
+        data = fields_to_nested_dict(fields)
+        return json.dumps(self.coerce_value(data), indent=2) + "\n"
 
     def coerce_value(self, value: Any) -> Any:
         """Convert non-JSON-native types to serialisable equivalents."""
@@ -463,48 +495,39 @@ class JSONConfigGenerator(ConfigGenerator):
 
 
 class TOMLConfigGenerator(ConfigGenerator):
-    """Render a parser to TOML. Help text is emitted as ``# <text>``
-    comments above each key. Nested groups use dotted table headers
-    (``[parent.child]``).
+    """Render a parser to TOML.
 
-    Minimal hand-rolled emitter — covers str, int, float, bool, list,
-    None. Other types are coerced via ``str()``.
+    Help text is emitted as ``# <text>`` comments above each key.
+    Nested groups use dotted table headers (``[parent.child]``).
+
+    Minimal hand-rolled emitter — covers ``str``/``int``/``float``/
+    ``bool``/``list``/``None``. Other types are coerced via ``str()``.
     """
 
     extension = ".toml"
 
-    def render(
-        self,
-        data: Dict[str, Any],
-        help_map: Optional[HelpMap] = None,
-    ) -> str:
-        help_map = help_map or {}
-        root: Dict[str, Any] = {}
-        sections: Dict[str, Dict[str, Any]] = {}
-        for key, value in data.items():
-            if isinstance(value, dict):
-                flatten_sections((key,), value, sections)
-            else:
-                root[key] = value
-
+    def render(self, fields: Iterable[ConfigField]) -> str:
+        sections = group_fields_by_section(fields)
         lines: List[str] = []
-        for key, value in root.items():
-            if value is None:
+        root_fields = sections.pop((), [])
+        for field in root_fields:
+            if field.value is None:
                 continue
-            if text := help_map.get((key,)):
-                lines.append(f"# {text}")
-            lines.append(f"{key} = {self.render_value(value)}")
-        if root and sections:
+            if field.help:
+                lines.append(f"# {field.help}")
+            lines.append(f"{field.key} = {self.render_value(field.value)}")
+        if root_fields and sections:
             lines.append("")
-        for section_name, items in sections.items():
-            section_path = tuple(section_name.split("."))
-            lines.append(f"[{section_name}]")
-            for key, value in items.items():
-                if value is None:
+        for path, items in sections.items():
+            lines.append(f"[{'.'.join(path)}]")
+            for field in items:
+                if field.value is None:
                     continue
-                if text := help_map.get(section_path + (key,)):
-                    lines.append(f"# {text}")
-                lines.append(f"{key} = {self.render_value(value)}")
+                if field.help:
+                    lines.append(f"# {field.help}")
+                lines.append(
+                    f"{field.key} = {self.render_value(field.value)}",
+                )
             lines.append("")
         return "\n".join(lines)
 
@@ -534,73 +557,34 @@ class TOMLConfigGenerator(ConfigGenerator):
 class EnvConfigGenerator(ConfigGenerator):
     """Render a parser to a ``.env``-style listing.
 
-    Emits one ``KEY=value`` line per argument, where ``KEY`` is the
-    env var name argclass would read (explicit ``env_var=`` on the
-    argument, or computed from the parser's ``auto_env_var_prefix``).
-    Arguments without a resolvable env var are skipped — set
-    ``auto_env_var_prefix=`` on the parser to get full coverage.
+    Emits one ``KEY=value`` line per argument that has a resolvable
+    env var (explicit ``env_var=`` on the argument or computed from
+    the parser's ``auto_env_var_prefix=``). Arguments without an env
+    var are skipped.
 
-    Help text is emitted as ``# <text>`` comments above each key.
-    Lists are serialised as Python literal syntax (e.g. ``['a','b']``)
-    so argclass can ``ast.literal_eval`` them when reading back.
+    Help text appears as ``# <text>`` comments above each key.
+    ``None`` values are dropped. Lists serialise to Python literal
+    syntax so argclass can ``ast.literal_eval`` them on read.
 
-    Strings are quoted only when they contain whitespace or special
-    characters — most ``.env`` parsers accept either form, but quoting
-    when needed avoids accidental tokenisation.
+    Strings are quoted only when they contain whitespace, ``=``,
+    ``#``, or other characters that would confuse a typical ``.env``
+    parser.
     """
 
     extension = ".env"
     QUOTE_CHARS = frozenset(' \t\n"\\#=')
 
-    def dump_to_string(
-        self,
-        parser: AbstractParser,
-        *,
-        namespace: Optional[argparse.Namespace] = None,
-    ) -> str:
-        data = self.build_dict(parser, namespace=namespace)
-        help_map = self.build_help_map(parser)
-        env_map = self.build_env_map(parser)
+    def render(self, fields: Iterable[ConfigField]) -> str:
         lines: List[str] = []
-        self.walk_env(data, (), env_map, help_map, lines)
+        for field in fields:
+            if field.env_var is None:
+                continue
+            if field.value is None:
+                continue
+            if field.help:
+                lines.append(f"# {field.help}")
+            lines.append(f"{field.env_var}={self.render_value(field.value)}")
         return "\n".join(lines) + ("\n" if lines else "")
-
-    def render(
-        self,
-        data: Dict[str, Any],
-        help_map: Optional[HelpMap] = None,
-    ) -> str:
-        # ``render`` cannot supply env names from the dict alone;
-        # the .env emitter overrides ``dump_to_string`` to compose
-        # data + help + env maps. Direct ``render`` calls would lose
-        # env_var info, so we explicitly forbid that path.
-        raise NotImplementedError(
-            "EnvConfigGenerator.render needs env metadata; use "
-            "dump_to_string(parser) or dump(parser, dest) instead.",
-        )
-
-    def walk_env(
-        self,
-        data: Dict[str, Any],
-        path: Tuple[str, ...],
-        env_map: EnvMap,
-        help_map: HelpMap,
-        lines: List[str],
-    ) -> None:
-        for key, value in data.items():
-            full_path = path + (key,)
-            if isinstance(value, dict):
-                self.walk_env(value, full_path, env_map, help_map, lines)
-                continue
-            env_name = env_map.get(full_path)
-            if env_name is None:
-                continue
-            if value is None:
-                continue
-            help_text = help_map.get(full_path)
-            if help_text:
-                lines.append(f"# {help_text}")
-            lines.append(f"{env_name}={self.render_value(value)}")
 
     def render_value(self, value: Any) -> str:
         if isinstance(value, bool):

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -1,0 +1,578 @@
+"""Config-file generators: render an argclass Parser to INI/JSON/TOML.
+
+Symmetric counterpart to ``argclass/defaults.py`` (which READS configs).
+Generators walk the parser tree (mirroring the recursion used by
+``Parser._fill_group``), produce a nested dict, and render it.
+
+Subclass ``ConfigGenerator`` and override ``render`` to add a new
+format. The walking + Action wiring are shared.
+
+Usage::
+
+    import argclass
+    from argclass.emit import GenerateConfigAction, INIConfigGenerator
+
+    class CLI(argclass.Parser):
+        host: str = "localhost"
+        generate = argclass.Argument(
+            "--generate-config",
+            action=GenerateConfigAction,
+            generator=INIConfigGenerator,
+            metavar="FILE",
+        )
+
+Run ``myapp --generate-config /etc/myapp.ini`` to write the file, or
+``myapp --generate-config -`` to print to stdout.
+
+Security note: secret values are emitted as-is. Treat generated files
+like any credential-bearing file.
+"""
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, IO, List, Optional, Tuple, Union, cast
+
+from .store import AbstractGroup, AbstractParser, TypedArgument
+from .types import Actions
+
+
+class NonConfigAction(argparse.Action):
+    """Base class for argparse Actions that should NOT appear in
+    config dumps produced by :class:`ConfigGenerator` subclasses.
+
+    Use this as a base for any "fire and exit" style action — like
+    ``--version``, ``--check-updates``, or ``--generate-config``
+    itself. ``ConfigGenerator`` checks ``__emit_config__`` on the
+    action class; when it is ``False``, the argument is skipped.
+
+    Stateful custom actions don't need to inherit anything — they're
+    included by default. Only inherit from ``NonConfigAction`` (or
+    set ``__emit_config__ = False`` manually) for actions whose
+    presence in a dumped config makes no sense.
+    """
+
+    __emit_config__ = False
+
+
+def should_emit(argument: TypedArgument) -> bool:
+    """True if this argument should appear in a generated config.
+
+    Action classes opt out via ``__emit_config__ = False`` (e.g. by
+    inheriting :class:`NonConfigAction`). argparse's built-in
+    ``--help`` / ``--version`` actions are recognised by enum value
+    since we cannot annotate argparse internals.
+    """
+    action = argument.action
+    if isinstance(action, type):
+        return bool(getattr(action, "__emit_config__", True))
+    # Actions enum members compare equal to their string values, so
+    # one membership test covers both Actions.HELP / Actions.VERSION
+    # and the raw "help" / "version" strings argparse accepts.
+    if action in (Actions.VERSION, Actions.HELP):
+        return False
+    return True
+
+
+def current_value(
+    target: Any,
+    name: str,
+    argument: TypedArgument,
+) -> Any:
+    """Read the current value for ``name`` on a Parser/Group instance.
+
+    After ``parse_args`` the value lives in ``__dict__``. Before
+    parsing, the instance attribute aliases the class attribute (which
+    argclass replaces with a sentinel), so we fall back to the
+    declared default on the TypedArgument.
+    """
+    if name in target.__dict__:
+        return target.__dict__[name]
+    return argument.default
+
+
+HelpMap = Dict[Tuple[str, ...], str]
+EnvMap = Dict[Tuple[str, ...], str]
+
+
+def derive_env_var(
+    auto_prefix: Optional[str],
+    dest: str,
+    argument: TypedArgument,
+) -> Optional[str]:
+    """Compute the env-var name argclass would read for ``dest``.
+
+    Mirrors :meth:`argclass.Parser.get_env_var`. Returns ``None`` when
+    neither an explicit ``env_var`` on the argument nor an
+    ``auto_env_var_prefix`` on the parser supplies one.
+    """
+    if argument.env_var is not None:
+        return argument.env_var
+    if auto_prefix is not None:
+        return f"{auto_prefix}{dest}".upper()
+    return None
+
+
+def group_cli_segment(group: AbstractGroup, attr_name: str) -> str:
+    """Return the CLI/env path segment for a group attribute, honoring
+    the group's ``prefix=`` override."""
+    prefix = getattr(group, "_prefix", None)
+    return prefix if prefix is not None else attr_name
+
+
+class ConfigGenerator:
+    """Walks an argclass Parser and renders its state to a config
+    string. Subclass and override :meth:`render` for a new format.
+
+    The walking + Action wiring live here; subclasses only need to
+    implement ``render(data, help_map) -> str``.
+    """
+
+    #: File extension hint. Subclasses set this.
+    extension: str = ""
+
+    def build_dict(self, parser: AbstractParser) -> Dict[str, Any]:
+        """Walk the parser, return a nested dict mirroring its tree.
+
+        Top-level arguments become root keys; each group becomes a
+        nested dict under its attribute name. Subparsers are skipped
+        (they represent runtime branches, not config-time state).
+        """
+        node = cast(Any, parser)
+        result: Dict[str, Any] = {}
+        for name, argument in node.__arguments__.items():
+            if not should_emit(argument):
+                continue
+            result[name] = current_value(parser, name, argument)
+        for group_name, group in node.__argument_groups__.items():
+            result[group_name] = self.build_group_dict(group)
+        return result
+
+    def build_group_dict(self, group: AbstractGroup) -> Dict[str, Any]:
+        node = cast(Any, group)
+        out: Dict[str, Any] = {}
+        for name, argument in node.__arguments__.items():
+            if not should_emit(argument):
+                continue
+            out[name] = current_value(group, name, argument)
+        for child_name, child_group in node.__argument_groups__.items():
+            out[child_name] = self.build_group_dict(child_group)
+        return out
+
+    def build_help_map(self, parser: AbstractParser) -> HelpMap:
+        """Return ``{path: help_text}`` for every leaf argument with
+        a help string. ``path`` is the tuple of attribute names from
+        the parser root down to the leaf."""
+        node = cast(Any, parser)
+        out: HelpMap = {}
+        for name, argument in node.__arguments__.items():
+            if argument.help and should_emit(argument):
+                out[(name,)] = argument.help
+        for group_name, group in node.__argument_groups__.items():
+            self.collect_group_help(group, (group_name,), out)
+        return out
+
+    def collect_group_help(
+        self,
+        group: AbstractGroup,
+        prefix: Tuple[str, ...],
+        out: HelpMap,
+    ) -> None:
+        node = cast(Any, group)
+        for name, argument in node.__arguments__.items():
+            if argument.help and should_emit(argument):
+                out[prefix + (name,)] = argument.help
+        for child_name, child in node.__argument_groups__.items():
+            self.collect_group_help(child, prefix + (child_name,), out)
+
+    def build_env_map(self, parser: AbstractParser) -> EnvMap:
+        """Return ``{path: env_var_name}`` for every leaf argument
+        that has an env var — either an explicit one on the argument
+        or one derived from the parser's ``auto_env_var_prefix``.
+
+        Arguments without a resolvable env var are omitted.
+        """
+        node = cast(Any, parser)
+        auto_prefix = getattr(parser, "_auto_env_var_prefix", None)
+        out: EnvMap = {}
+        for name, argument in node.__arguments__.items():
+            if not should_emit(argument):
+                continue
+            env = derive_env_var(auto_prefix, name, argument)
+            if env:
+                out[(name,)] = env
+        for group_name, group in node.__argument_groups__.items():
+            seg = group_cli_segment(group, group_name)
+            cli_path = (seg,) if seg else ()
+            self.collect_group_env(
+                group,
+                (group_name,),
+                cli_path,
+                auto_prefix,
+                out,
+            )
+        return out
+
+    def collect_group_env(
+        self,
+        group: AbstractGroup,
+        attr_path: Tuple[str, ...],
+        cli_path: Tuple[str, ...],
+        auto_prefix: Optional[str],
+        out: EnvMap,
+    ) -> None:
+        node = cast(Any, group)
+        cli_prefix = "_".join(cli_path)
+        for name, argument in node.__arguments__.items():
+            if not should_emit(argument):
+                continue
+            dest = f"{cli_prefix}_{name}" if cli_prefix else name
+            env = derive_env_var(auto_prefix, dest, argument)
+            if env:
+                out[attr_path + (name,)] = env
+        for child_name, child in node.__argument_groups__.items():
+            seg = group_cli_segment(child, child_name)
+            child_cli = cli_path + ((seg,) if seg else ())
+            self.collect_group_env(
+                child,
+                attr_path + (child_name,),
+                child_cli,
+                auto_prefix,
+                out,
+            )
+
+    def render(
+        self,
+        data: Dict[str, Any],
+        help_map: Optional[HelpMap] = None,
+    ) -> str:
+        """Render the dict to a config-format string. Override me."""
+        raise NotImplementedError
+
+    def dump_to_string(self, parser: AbstractParser) -> str:
+        """Convenience: build_dict + render in one call."""
+        return self.render(
+            self.build_dict(parser),
+            self.build_help_map(parser),
+        )
+
+    def dump(
+        self,
+        parser: AbstractParser,
+        dest: Union[str, IO[str]],
+    ) -> None:
+        """Write the rendered config to ``dest``.
+
+        ``dest`` may be a path, a file-like object, or the string
+        ``"-"`` (writes to stdout).
+        """
+        content = self.dump_to_string(parser)
+        if dest == "-":
+            sys.stdout.write(content)
+        elif isinstance(dest, str):
+            with open(dest, "w") as fp:
+                fp.write(content)
+        else:
+            dest.write(content)
+
+
+def flatten_sections(
+    path: Tuple[str, ...],
+    value: Dict[str, Any],
+    sections: Dict[str, Dict[str, Any]],
+) -> None:
+    """Recursively flatten nested-dict groups into dotted section names.
+
+    Shared helper for INI and TOML emitters, which both use
+    ``[parent.child]`` style section headers.
+    """
+    section_name = ".".join(path)
+    scalars: Dict[str, Any] = {}
+    for k, v in value.items():
+        if isinstance(v, dict):
+            flatten_sections(path + (k,), v, sections)
+        else:
+            scalars[k] = v
+    sections[section_name] = scalars
+
+
+class INIConfigGenerator(ConfigGenerator):
+    """Render a parser to INI. Help text is emitted as ``; <text>``
+    comments above each key. Nested groups use dotted section names
+    (``[parent.child]``)."""
+
+    extension = ".ini"
+
+    def render(
+        self,
+        data: Dict[str, Any],
+        help_map: Optional[HelpMap] = None,
+    ) -> str:
+        help_map = help_map or {}
+        root: Dict[str, Any] = {}
+        sections: Dict[str, Dict[str, Any]] = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                flatten_sections((key,), value, sections)
+            else:
+                root[key] = value
+
+        lines: List[str] = []
+        if root:
+            lines.append("[DEFAULT]")
+            for key, value in root.items():
+                if text := help_map.get((key,)):
+                    lines.append(f"; {text}")
+                lines.append(f"{key} = {self.render_scalar(value)}")
+            lines.append("")
+        for section_name, items in sections.items():
+            section_path = tuple(section_name.split("."))
+            lines.append(f"[{section_name}]")
+            for key, value in items.items():
+                if text := help_map.get(section_path + (key,)):
+                    lines.append(f"; {text}")
+                lines.append(f"{key} = {self.render_scalar(value)}")
+            lines.append("")
+        return "\n".join(lines)
+
+    @staticmethod
+    def render_scalar(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (list, tuple)):
+            return repr(list(value))
+        return str(value)
+
+
+class JSONConfigGenerator(ConfigGenerator):
+    """Render a parser to JSON. Comments are not supported by JSON,
+    so help text is dropped. Nested groups become nested objects."""
+
+    extension = ".json"
+
+    def render(
+        self,
+        data: Dict[str, Any],
+        help_map: Optional[HelpMap] = None,
+    ) -> str:
+        return (
+            json.dumps(self.coerce_value(data), indent=2, sort_keys=False)
+            + "\n"
+        )
+
+    def coerce_value(self, value: Any) -> Any:
+        """Convert non-JSON-native types to serialisable equivalents."""
+        if isinstance(value, dict):
+            return {k: self.coerce_value(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [self.coerce_value(v) for v in value]
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            return value
+        return str(value)
+
+
+class TOMLConfigGenerator(ConfigGenerator):
+    """Render a parser to TOML. Help text is emitted as ``# <text>``
+    comments above each key. Nested groups use dotted table headers
+    (``[parent.child]``).
+
+    Minimal hand-rolled emitter — covers str, int, float, bool, list,
+    None. Other types are coerced via ``str()``.
+    """
+
+    extension = ".toml"
+
+    def render(
+        self,
+        data: Dict[str, Any],
+        help_map: Optional[HelpMap] = None,
+    ) -> str:
+        help_map = help_map or {}
+        root: Dict[str, Any] = {}
+        sections: Dict[str, Dict[str, Any]] = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                flatten_sections((key,), value, sections)
+            else:
+                root[key] = value
+
+        lines: List[str] = []
+        for key, value in root.items():
+            if value is None:
+                continue
+            if text := help_map.get((key,)):
+                lines.append(f"# {text}")
+            lines.append(f"{key} = {self.render_value(value)}")
+        if root and sections:
+            lines.append("")
+        for section_name, items in sections.items():
+            section_path = tuple(section_name.split("."))
+            lines.append(f"[{section_name}]")
+            for key, value in items.items():
+                if value is None:
+                    continue
+                if text := help_map.get(section_path + (key,)):
+                    lines.append(f"# {text}")
+                lines.append(f"{key} = {self.render_value(value)}")
+            lines.append("")
+        return "\n".join(lines)
+
+    def render_value(self, value: Any) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return repr(value)
+        if isinstance(value, (list, tuple)):
+            inner = ", ".join(self.render_value(v) for v in value)
+            return f"[{inner}]"
+        return self.render_string(value)
+
+    @staticmethod
+    def render_string(value: Any) -> str:
+        s = str(value)
+        escaped = (
+            s.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
+        return f'"{escaped}"'
+
+
+class EnvConfigGenerator(ConfigGenerator):
+    """Render a parser to a ``.env``-style listing.
+
+    Emits one ``KEY=value`` line per argument, where ``KEY`` is the
+    env var name argclass would read (explicit ``env_var=`` on the
+    argument, or computed from the parser's ``auto_env_var_prefix``).
+    Arguments without a resolvable env var are skipped — set
+    ``auto_env_var_prefix=`` on the parser to get full coverage.
+
+    Help text is emitted as ``# <text>`` comments above each key.
+    Lists are serialised as Python literal syntax (e.g. ``['a','b']``)
+    so argclass can ``ast.literal_eval`` them when reading back.
+
+    Strings are quoted only when they contain whitespace or special
+    characters — most ``.env`` parsers accept either form, but quoting
+    when needed avoids accidental tokenisation.
+    """
+
+    extension = ".env"
+    QUOTE_CHARS = frozenset(' \t\n"\\#=')
+
+    def dump_to_string(self, parser: AbstractParser) -> str:
+        data = self.build_dict(parser)
+        help_map = self.build_help_map(parser)
+        env_map = self.build_env_map(parser)
+        lines: List[str] = []
+        self.walk_env(data, (), env_map, help_map, lines)
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    def render(
+        self,
+        data: Dict[str, Any],
+        help_map: Optional[HelpMap] = None,
+    ) -> str:
+        # ``render`` cannot supply env names from the dict alone;
+        # the .env emitter overrides ``dump_to_string`` to compose
+        # data + help + env maps. Direct ``render`` calls would lose
+        # env_var info, so we explicitly forbid that path.
+        raise NotImplementedError(
+            "EnvConfigGenerator.render needs env metadata; use "
+            "dump_to_string(parser) or dump(parser, dest) instead.",
+        )
+
+    def walk_env(
+        self,
+        data: Dict[str, Any],
+        path: Tuple[str, ...],
+        env_map: EnvMap,
+        help_map: HelpMap,
+        lines: List[str],
+    ) -> None:
+        for key, value in data.items():
+            full_path = path + (key,)
+            if isinstance(value, dict):
+                self.walk_env(value, full_path, env_map, help_map, lines)
+                continue
+            env_name = env_map.get(full_path)
+            if env_name is None:
+                continue
+            if value is None:
+                continue
+            help_text = help_map.get(full_path)
+            if help_text:
+                lines.append(f"# {help_text}")
+            lines.append(f"{env_name}={self.render_value(value)}")
+
+    def render_value(self, value: Any) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return repr(value)
+        if isinstance(value, (list, tuple)):
+            return repr(list(value))
+        return self.quote_string(str(value))
+
+    def quote_string(self, value: str) -> str:
+        if not value:
+            return ""
+        if any(c in self.QUOTE_CHARS for c in value):
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped}"'
+        return value
+
+
+class GenerateConfigAction(NonConfigAction):
+    """Argparse Action: ``--generate-config FILE``.
+
+    ``FILE`` may be a filesystem path or ``-`` for stdout. Pass the
+    generator class (or instance) via the ``generator=`` passthrough
+    kwarg::
+
+        argclass.Argument(
+            "--generate-config",
+            action=GenerateConfigAction,
+            generator=INIConfigGenerator,
+        )
+
+    On invocation, walks the parser, renders the config, writes to the
+    destination, and exits the process with status 0.
+    """
+
+    def __init__(
+        self,
+        option_strings: List[str],
+        dest: str,
+        generator: Union[type, ConfigGenerator],
+        **kwargs: Any,
+    ):
+        kwargs.setdefault("nargs", 1)
+        kwargs.setdefault("metavar", "FILE")
+        kwargs.setdefault("default", argparse.SUPPRESS)
+        if isinstance(generator, type):
+            self.generator: ConfigGenerator = generator()
+        else:
+            self.generator = generator
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: Optional[str] = None,
+    ) -> None:
+        argclass_parser = getattr(parser, "argclass_parser", None)
+        if argclass_parser is None:
+            parser.error(
+                "argclass parser back-reference missing — "
+                "GenerateConfigAction requires the parser to be built "
+                "through argclass.Parser.parse_args",
+            )
+        path = values[0] if isinstance(values, list) else values
+        self.generator.dump(argclass_parser, path)
+        parser.exit(0)

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -30,6 +30,7 @@ like any credential-bearing file.
 
 import argparse
 import json
+import os
 import sys
 from typing import Any, Dict, IO, List, Optional, Tuple, Union, cast
 
@@ -78,16 +79,44 @@ def current_value(
     target: Any,
     name: str,
     argument: TypedArgument,
+    *,
+    namespace: Optional[argparse.Namespace] = None,
+    dest: Optional[str] = None,
+    env_var: Optional[str] = None,
 ) -> Any:
     """Read the current value for ``name`` on a Parser/Group instance.
 
-    After ``parse_args`` the value lives in ``__dict__``. Before
-    parsing, the instance attribute aliases the class attribute (which
-    argclass replaces with a sentinel), so we fall back to the
-    declared default on the TypedArgument.
+    Priority (highest first):
+
+    1. The instance ``__dict__`` (set when ``parse_args`` has
+       completed).
+    2. An argparse ``Namespace`` under ``dest`` — used when called
+       mid-parse from :class:`GenerateConfigAction`, so CLI flags
+       already processed by argparse land in the dump.
+    3. ``os.environ[env_var]`` — covers env vars when the dump runs
+       before argclass has applied them to ``__dict__``.
+    4. The argument's declared default.
+
+    Env values arrive as strings; we apply ``argument.type`` when it
+    is callable, so the dump reflects the same type argclass would
+    bind at parse time.
     """
     if name in target.__dict__:
         return target.__dict__[name]
+    if namespace is not None and dest is not None and hasattr(namespace, dest):
+        value = getattr(namespace, dest)
+        if value is not None:
+            return value
+    if env_var:
+        raw = os.environ.get(env_var)
+        if raw is not None:
+            type_func = argument.type
+            if type_func is not None and not isinstance(raw, type_func):
+                try:
+                    return type_func(raw)
+                except Exception:
+                    return raw
+            return raw
     return argument.default
 
 
@@ -131,32 +160,82 @@ class ConfigGenerator:
     #: File extension hint. Subclasses set this.
     extension: str = ""
 
-    def build_dict(self, parser: AbstractParser) -> Dict[str, Any]:
+    def build_dict(
+        self,
+        parser: AbstractParser,
+        *,
+        namespace: Optional[argparse.Namespace] = None,
+    ) -> Dict[str, Any]:
         """Walk the parser, return a nested dict mirroring its tree.
 
         Top-level arguments become root keys; each group becomes a
         nested dict under its attribute name. Subparsers are skipped
         (they represent runtime branches, not config-time state).
+
+        When ``namespace`` is provided, values are read from it (and
+        from ``os.environ`` for args with env vars) — used by
+        :class:`GenerateConfigAction` so the dump reflects CLI flags
+        and env vars even when triggered mid-parse.
         """
         node = cast(Any, parser)
+        auto_prefix = getattr(parser, "_auto_env_var_prefix", None)
         result: Dict[str, Any] = {}
         for name, argument in node.__arguments__.items():
             if not should_emit(argument):
                 continue
-            result[name] = current_value(parser, name, argument)
+            env = derive_env_var(auto_prefix, name, argument)
+            result[name] = current_value(
+                parser,
+                name,
+                argument,
+                namespace=namespace,
+                dest=name,
+                env_var=env,
+            )
         for group_name, group in node.__argument_groups__.items():
-            result[group_name] = self.build_group_dict(group)
+            seg = group_cli_segment(group, group_name)
+            cli_path = (seg,) if seg else ()
+            result[group_name] = self.build_group_dict(
+                group,
+                cli_path=cli_path,
+                auto_prefix=auto_prefix,
+                namespace=namespace,
+            )
         return result
 
-    def build_group_dict(self, group: AbstractGroup) -> Dict[str, Any]:
+    def build_group_dict(
+        self,
+        group: AbstractGroup,
+        *,
+        cli_path: Tuple[str, ...] = (),
+        auto_prefix: Optional[str] = None,
+        namespace: Optional[argparse.Namespace] = None,
+    ) -> Dict[str, Any]:
         node = cast(Any, group)
+        cli_prefix = "_".join(cli_path)
         out: Dict[str, Any] = {}
         for name, argument in node.__arguments__.items():
             if not should_emit(argument):
                 continue
-            out[name] = current_value(group, name, argument)
+            dest = f"{cli_prefix}_{name}" if cli_prefix else name
+            env = derive_env_var(auto_prefix, dest, argument)
+            out[name] = current_value(
+                group,
+                name,
+                argument,
+                namespace=namespace,
+                dest=dest,
+                env_var=env,
+            )
         for child_name, child_group in node.__argument_groups__.items():
-            out[child_name] = self.build_group_dict(child_group)
+            seg = group_cli_segment(child_group, child_name)
+            child_cli = cli_path + ((seg,) if seg else ())
+            out[child_name] = self.build_group_dict(
+                child_group,
+                cli_path=child_cli,
+                auto_prefix=auto_prefix,
+                namespace=namespace,
+            )
         return out
 
     def build_help_map(self, parser: AbstractParser) -> HelpMap:
@@ -249,10 +328,15 @@ class ConfigGenerator:
         """Render the dict to a config-format string. Override me."""
         raise NotImplementedError
 
-    def dump_to_string(self, parser: AbstractParser) -> str:
+    def dump_to_string(
+        self,
+        parser: AbstractParser,
+        *,
+        namespace: Optional[argparse.Namespace] = None,
+    ) -> str:
         """Convenience: build_dict + render in one call."""
         return self.render(
-            self.build_dict(parser),
+            self.build_dict(parser, namespace=namespace),
             self.build_help_map(parser),
         )
 
@@ -260,13 +344,15 @@ class ConfigGenerator:
         self,
         parser: AbstractParser,
         dest: Union[str, IO[str]],
+        *,
+        namespace: Optional[argparse.Namespace] = None,
     ) -> None:
         """Write the rendered config to ``dest``.
 
         ``dest`` may be a path, a file-like object, or the string
         ``"-"`` (writes to stdout).
         """
-        content = self.dump_to_string(parser)
+        content = self.dump_to_string(parser, namespace=namespace)
         if dest == "-":
             sys.stdout.write(content)
         elif isinstance(dest, str):
@@ -463,8 +549,13 @@ class EnvConfigGenerator(ConfigGenerator):
     extension = ".env"
     QUOTE_CHARS = frozenset(' \t\n"\\#=')
 
-    def dump_to_string(self, parser: AbstractParser) -> str:
-        data = self.build_dict(parser)
+    def dump_to_string(
+        self,
+        parser: AbstractParser,
+        *,
+        namespace: Optional[argparse.Namespace] = None,
+    ) -> str:
+        data = self.build_dict(parser, namespace=namespace)
         help_map = self.build_help_map(parser)
         env_map = self.build_env_map(parser)
         lines: List[str] = []
@@ -574,5 +665,5 @@ class GenerateConfigAction(NonConfigAction):
                 "through argclass.Parser.parse_args",
             )
         path = values[0] if isinstance(values, list) else values
-        self.generator.dump(argclass_parser, path)
+        self.generator.dump(argclass_parser, path, namespace=namespace)
         parser.exit(0)

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -103,25 +103,28 @@ def current_value(
 
     Priority (highest first):
 
-    1. The instance ``__dict__`` (set when ``parse_args`` has
-       completed).
-    2. An argparse ``Namespace`` under ``dest`` — used when called
-       mid-parse from :class:`GenerateConfigAction`, so CLI flags
-       already processed by argparse land in the dump.
-    3. ``os.environ[env_var]`` — covers env vars when the dump runs
-       before argclass has applied them to ``__dict__``.
+    1. An argparse ``Namespace`` under ``dest`` — when provided, it
+       represents the active parse and wins over stale instance
+       state. Used by :class:`GenerateConfigAction` so a reused
+       parser doesn't dump values from an earlier ``parse_args``
+       call.
+    2. The instance ``__dict__`` (set when an earlier
+       ``parse_args`` completed, or when the field is a Group whose
+       attributes argclass populated after parsing).
+    3. ``os.environ[env_var]`` — covers env vars when the dump
+       runs before argclass has applied them to ``__dict__``.
     4. The argument's declared default.
 
     Env values arrive as strings; we apply ``argument.type`` when it
     is callable, so the dump reflects the same type argclass would
     bind at parse time.
     """
-    if name in target.__dict__:
-        return target.__dict__[name]
     if namespace is not None and dest is not None and hasattr(namespace, dest):
         value = getattr(namespace, dest)
         if value is not None:
             return value
+    if name in target.__dict__:
+        return target.__dict__[name]
     if env_var:
         raw = os.environ.get(env_var)
         if raw is not None:
@@ -152,6 +155,22 @@ def group_cli_segment(group: AbstractGroup, attr_name: str) -> str:
     the group's ``prefix=`` override."""
     prefix = getattr(group, "_prefix", None)
     return prefix if prefix is not None else attr_name
+
+
+def escape_inline_string(value: str) -> str:
+    """Escape a string for embedding inside double-quoted literals.
+
+    Used by both TOML (always quoted) and the ``.env`` emitter
+    (quoted on demand) so multi-line / tab / quote-bearing values
+    stay on a single line and survive a shell parser.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
 
 
 def normalize_value(value: Any) -> Any:
@@ -545,15 +564,7 @@ class TOMLConfigGenerator(ConfigGenerator):
 
     @staticmethod
     def render_string(value: Any) -> str:
-        s = str(value)
-        escaped = (
-            s.replace("\\", "\\\\")
-            .replace('"', '\\"')
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t")
-        )
-        return f'"{escaped}"'
+        return f'"{escape_inline_string(str(value))}"'
 
 
 class EnvConfigGenerator(ConfigGenerator):
@@ -574,7 +585,7 @@ class EnvConfigGenerator(ConfigGenerator):
     """
 
     extension = ".env"
-    QUOTE_CHARS = frozenset(' \t\n"\\#=')
+    QUOTE_CHARS = frozenset(' \t\n\r"\\#=')
 
     def render(self, fields: Sequence[ConfigField]) -> str:
         lines: List[str] = []
@@ -601,8 +612,7 @@ class EnvConfigGenerator(ConfigGenerator):
         if not value:
             return ""
         if any(c in self.QUOTE_CHARS for c in value):
-            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-            return f'"{escaped}"'
+            return f'"{escape_inline_string(value)}"'
         return value
 
 

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -30,7 +30,6 @@ like any credential-bearing file.
 """
 
 import argparse
-import ast
 import json
 import os
 import sys
@@ -45,6 +44,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Sequence,
     Tuple,
     Union,
     cast,
@@ -52,8 +52,8 @@ from typing import (
 
 from .parser import get_argclass_parser
 from .store import AbstractGroup, AbstractParser, TypedArgument
-from .types import Actions, Nargs
-from .utils import parse_bool
+from .types import Actions
+from .utils import coerce_env_default
 
 
 class NonConfigAction(argparse.Action):
@@ -125,57 +125,8 @@ def current_value(
     if env_var:
         raw = os.environ.get(env_var)
         if raw is not None:
-            return coerce_env_value(raw, argument)
+            return coerce_env_default(raw, argument)
     return argument.default
-
-
-def nargs_is_list(argument: TypedArgument) -> bool:
-    """Return whether argparse will treat the argument as a sequence."""
-    return (
-        argument.nargs in (Nargs.ONE_OR_MORE, Nargs.ZERO_OR_MORE, "*", "+")
-        or isinstance(argument.nargs, int)
-        and argument.nargs >= 1
-    )
-
-
-def coerce_env_value(raw: str, argument: TypedArgument) -> Any:
-    """Apply the same env-var coercions used while building argparse.
-
-    ``GenerateConfigAction`` can run before argclass has copied parsed
-    values back to Parser/Group instances. In that path we still need
-    env values to look like parsed values, including sequence defaults,
-    bool flags, and callable ``type=`` converters.
-    """
-    if raw and nargs_is_list(argument):
-        try:
-            return list(map(argument.type or str, ast.literal_eval(raw)))
-        except Exception:
-            return raw
-
-    if argument.action in (
-        Actions.STORE_TRUE,
-        Actions.STORE_FALSE,
-        "store_true",
-        "store_false",
-    ):
-        return parse_bool(raw)
-
-    type_func = argument.type
-    if type_func is None:
-        return raw
-
-    try:
-        already_correct = isinstance(raw, type_func)
-    except TypeError:
-        already_correct = False
-
-    if already_correct:
-        return raw
-
-    try:
-        return type_func(raw)
-    except Exception:
-        return raw
 
 
 def derive_env_var(
@@ -404,11 +355,16 @@ class ConfigGenerator:
     #: File extension hint. Subclasses set this.
     extension: str = ""
 
-    def render(self, fields: Iterable[ConfigField]) -> str:
-        """Render a stream of :class:`ConfigField` records to text.
+    def render(self, fields: Sequence[ConfigField]) -> str:
+        """Render a sequence of :class:`ConfigField` records to text.
 
-        Override this for a new format. Default implementation just
-        raises — every format has to decide how to lay out fields.
+        Override this for a new format. ``fields`` is a materialised
+        sequence — implementations may iterate it more than once
+        (e.g. to split into header / sections) without burning
+        through an exhausted iterator.
+
+        Default implementation just raises — every format has to
+        decide how to lay out fields.
         """
         raise NotImplementedError
 
@@ -420,9 +376,10 @@ class ConfigGenerator:
     ) -> str:
         """Walk ``parser`` and return the rendered config as a
         string."""
-        return self.render(
-            iter_config_fields(parser, namespace=namespace),
-        )
+        # Materialise into a tuple so ``render`` (and any custom
+        # subclass) can iterate the field stream multiple times.
+        fields = tuple(iter_config_fields(parser, namespace=namespace))
+        return self.render(fields)
 
     def dump(
         self,
@@ -478,7 +435,7 @@ class INIConfigGenerator(ConfigGenerator):
 
     extension = ".ini"
 
-    def render(self, fields: Iterable[ConfigField]) -> str:
+    def render(self, fields: Sequence[ConfigField]) -> str:
         sections = group_fields_by_section(fields)
         lines: List[str] = []
         root_fields = sections.pop((), [])
@@ -524,7 +481,7 @@ class JSONConfigGenerator(ConfigGenerator):
 
     extension = ".json"
 
-    def render(self, fields: Iterable[ConfigField]) -> str:
+    def render(self, fields: Sequence[ConfigField]) -> str:
         data = fields_to_nested_dict(fields)
         return json.dumps(self.coerce_value(data), indent=2) + "\n"
 
@@ -551,7 +508,7 @@ class TOMLConfigGenerator(ConfigGenerator):
 
     extension = ".toml"
 
-    def render(self, fields: Iterable[ConfigField]) -> str:
+    def render(self, fields: Sequence[ConfigField]) -> str:
         sections = group_fields_by_section(fields)
         lines: List[str] = []
         root_fields = sections.pop((), [])
@@ -619,7 +576,7 @@ class EnvConfigGenerator(ConfigGenerator):
     extension = ".env"
     QUOTE_CHARS = frozenset(' \t\n"\\#=')
 
-    def render(self, fields: Iterable[ConfigField]) -> str:
+    def render(self, fields: Sequence[ConfigField]) -> str:
         lines: List[str] = []
         for field in fields:
             if field.env_var is None:

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -30,6 +30,7 @@ like any credential-bearing file.
 """
 
 import argparse
+import ast
 import json
 import os
 import sys
@@ -51,7 +52,8 @@ from typing import (
 
 from .parser import get_argclass_parser
 from .store import AbstractGroup, AbstractParser, TypedArgument
-from .types import Actions
+from .types import Actions, Nargs
+from .utils import parse_bool
 
 
 class NonConfigAction(argparse.Action):
@@ -123,14 +125,57 @@ def current_value(
     if env_var:
         raw = os.environ.get(env_var)
         if raw is not None:
-            type_func = argument.type
-            if type_func is not None and not isinstance(raw, type_func):
-                try:
-                    return type_func(raw)
-                except Exception:
-                    return raw
-            return raw
+            return coerce_env_value(raw, argument)
     return argument.default
+
+
+def nargs_is_list(argument: TypedArgument) -> bool:
+    """Return whether argparse will treat the argument as a sequence."""
+    return (
+        argument.nargs in (Nargs.ONE_OR_MORE, Nargs.ZERO_OR_MORE, "*", "+")
+        or isinstance(argument.nargs, int)
+        and argument.nargs >= 1
+    )
+
+
+def coerce_env_value(raw: str, argument: TypedArgument) -> Any:
+    """Apply the same env-var coercions used while building argparse.
+
+    ``GenerateConfigAction`` can run before argclass has copied parsed
+    values back to Parser/Group instances. In that path we still need
+    env values to look like parsed values, including sequence defaults,
+    bool flags, and callable ``type=`` converters.
+    """
+    if raw and nargs_is_list(argument):
+        try:
+            return list(map(argument.type or str, ast.literal_eval(raw)))
+        except Exception:
+            return raw
+
+    if argument.action in (
+        Actions.STORE_TRUE,
+        Actions.STORE_FALSE,
+        "store_true",
+        "store_false",
+    ):
+        return parse_bool(raw)
+
+    type_func = argument.type
+    if type_func is None:
+        return raw
+
+    try:
+        already_correct = isinstance(raw, type_func)
+    except TypeError:
+        already_correct = False
+
+    if already_correct:
+        return raw
+
+    try:
+        return type_func(raw)
+    except Exception:
+        return raw
 
 
 def derive_env_var(
@@ -425,10 +470,10 @@ class INIConfigGenerator(ConfigGenerator):
     sections (``[endpoint.credentials]``). Help text is emitted as
     ``; <text>`` comments above each key.
 
-    Caveat: configparser's ``[DEFAULT]`` section cascades into every
-    other section. If a top-level argument shares a name with a group
-    attribute, the top-level value will be inherited by the group on
-    reload. Rename one of the colliding attributes to avoid this.
+    Note: configparser's ``[DEFAULT]`` section would normally cascade
+    into every other section, but
+    :class:`argclass.INIDefaultsParser` strips that cascade on read so
+    a top-level ``host`` cannot leak into a group's ``host`` attribute.
     """
 
     extension = ".ini"

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -2,6 +2,7 @@
 
 import ast
 import os
+import weakref
 from abc import ABCMeta
 from argparse import Action, ArgumentParser
 from collections import defaultdict
@@ -399,6 +400,30 @@ class Group(AbstractGroup, Base):
 ParserType = TypeVar("ParserType", bound="Parser")
 
 
+# Out-of-band back-references: argparse_parser -> argclass Parser.
+# Lets custom actions (e.g. ``GenerateConfigAction``) recover the
+# argclass Parser without mutating any argparse object. Auto-cleans
+# entries when the argparse parser is garbage-collected.
+_BackRefMap = weakref.WeakKeyDictionary
+_argclass_back_refs: "_BackRefMap[ArgumentParser, AbstractParser]" = (
+    _BackRefMap()
+)
+
+
+def get_argclass_parser(
+    argparse_parser: ArgumentParser,
+) -> Optional["Parser"]:
+    """Return the :class:`argclass.Parser` that built
+    ``argparse_parser``, or ``None`` if it wasn't built through
+    argclass (e.g. a bare ``argparse.ArgumentParser``).
+
+    Useful for writing custom argparse Actions that need access to
+    the argclass-level parser at invocation time —
+    :class:`argclass.GenerateConfigAction` uses this internally.
+    """
+    return _argclass_back_refs.get(argparse_parser)  # type: ignore[return-value]
+
+
 # noinspection PyProtectedMember
 class Parser(AbstractParser, Base):
     """Main parser class for command-line argument parsing."""
@@ -587,7 +612,7 @@ class Parser(AbstractParser, Base):
                 **self._parser_kwargs,
             )
 
-        parser.argclass_parser = self  # type: ignore[attr-defined]
+        _argclass_back_refs[parser] = self
 
         destinations: DestinationsType = defaultdict(set)
         self._fill_arguments(destinations, parser)

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -587,6 +587,8 @@ class Parser(AbstractParser, Base):
                 **self._parser_kwargs,
             )
 
+        parser.argclass_parser = self  # type: ignore[attr-defined]
+
         destinations: DestinationsType = defaultdict(set)
         self._fill_arguments(destinations, parser)
         self._fill_groups(destinations, parser)

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -463,18 +463,20 @@ class Parser(AbstractParser, Base):
             ).strip()
 
         if argument.env_var is not None:
-            default = kwargs.get("default")
-            raw = os.getenv(argument.env_var, default)
-            kwargs["default"] = coerce_env_default(raw, argument)
+            # Only coerce when the env var was actually set; an
+            # absent env must not retype the existing default
+            # (a string ``"0"`` default with ``type=int`` would
+            # otherwise silently become the integer ``0`` here).
+            raw = os.environ.get(argument.env_var)
+            if raw is not None:
+                kwargs["default"] = coerce_env_default(raw, argument)
+                self._used_env_vars.add(argument.env_var)
+                if argument.secret:
+                    self._used_secret_env_vars.add(argument.env_var)
 
             kwargs["help"] = (
                 f"{kwargs.get('help', '')} [ENV: {argument.env_var}]"
             ).strip()
-
-            if argument.env_var in os.environ:
-                self._used_env_vars.add(argument.env_var)
-                if argument.secret:
-                    self._used_secret_env_vars.add(argument.env_var)
 
         # Safety net: env vars are read above, so default may have changed.
         # If we now have a default, remove the required flag.

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -1,6 +1,5 @@
 """Core parser classes for argclass."""
 
-import ast
 import os
 import weakref
 from abc import ABCMeta
@@ -42,6 +41,7 @@ from .store import AbstractGroup, AbstractParser, TypedArgument
 from .types import Actions, Nargs
 from .utils import (
     _unwrap_container_type,
+    coerce_env_default,
     deep_getattr,
     parse_bool,
     resolve_annotations,
@@ -462,29 +462,10 @@ class Parser(AbstractParser, Base):
                 f"{kwargs.get('help', '')} (default: {argument.default})"
             ).strip()
 
-        # Check if nargs produces a list
-        nargs_is_list = (
-            argument.nargs in (Nargs.ONE_OR_MORE, Nargs.ZERO_OR_MORE, "*", "+")
-            or isinstance(argument.nargs, int)
-            and argument.nargs >= 1
-        )
-
         if argument.env_var is not None:
             default = kwargs.get("default")
-            kwargs["default"] = os.getenv(argument.env_var, default)
-
-            # Parse env var string for nargs (only if still a string)
-            if (
-                isinstance(kwargs["default"], str)
-                and kwargs["default"]
-                and nargs_is_list
-            ):
-                kwargs["default"] = list(
-                    map(
-                        argument.type or str,
-                        ast.literal_eval(kwargs["default"]),
-                    ),
-                )
+            raw = os.getenv(argument.env_var, default)
+            kwargs["default"] = coerce_env_default(raw, argument)
 
             kwargs["help"] = (
                 f"{kwargs.get('help', '')} [ENV: {argument.env_var}]"
@@ -494,17 +475,6 @@ class Parser(AbstractParser, Base):
                 self._used_env_vars.add(argument.env_var)
                 if argument.secret:
                     self._used_secret_env_vars.add(argument.env_var)
-
-        # Convert string boolean values from config/env to proper bools
-        action = kwargs.get("action")
-        default = kwargs.get("default")
-        if isinstance(default, str) and action in (
-            Actions.STORE_TRUE,
-            Actions.STORE_FALSE,
-            "store_true",
-            "store_false",
-        ):
-            kwargs["default"] = parse_bool(default)
 
         # Safety net: env vars are read above, so default may have changed.
         # If we now have a default, remove the required flag.

--- a/argclass/utils.py
+++ b/argclass/utils.py
@@ -55,10 +55,32 @@ def read_ini_configs(
     )
 
     for section in parser.sections():
-        config = dict(parser.items(section, raw=True))
-        result[section] = config
+        result[section] = own_section_items(parser, section)
 
     return result, tuple(map(Path, config_paths))
+
+
+def own_section_items(
+    parser: configparser.ConfigParser,
+    section: str,
+) -> Dict[str, str]:
+    """Return ``section``'s own keys, excluding cascaded ``[DEFAULT]``.
+
+    configparser's public API
+    (``parser.items(section, raw=True)`` / ``parser[section]``)
+    inherits keys from ``[DEFAULT]`` into every section. argclass
+    groups are independent argument namespaces — a top-level
+    ``host = root`` must not leak into ``[inner].host`` when the
+    group's own default is ``None``.
+
+    There's no documented opt-out, so this helper isolates the
+    one place where we reach into ``parser._sections``. Keeps the
+    private-attribute risk to a single well-commented call site.
+    """
+    own: Dict[str, str] = dict(
+        parser._sections[section],  # type: ignore[attr-defined]
+    )
+    return own
 
 
 def deep_getattr(name: str, attrs: Dict[str, Any], *bases: Type) -> Any:

--- a/argclass/utils.py
+++ b/argclass/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for argclass."""
 
+import ast
 import configparser
 import os
 import types
@@ -22,6 +23,8 @@ from .exceptions import ComplexTypeError
 from .types import (
     CONTAINER_TYPES,
     TEXT_TRUE_VALUES,
+    Actions,
+    Nargs,
     NoneType,
     UnionClass,
 )
@@ -102,6 +105,61 @@ def resolve_annotations(cls: type) -> Dict[str, Any]:
 def parse_bool(value: str) -> bool:
     """Parse a string to boolean."""
     return value.lower() in TEXT_TRUE_VALUES
+
+
+def nargs_is_list(argument: Any) -> bool:
+    """Return True when argparse will treat ``argument`` as a sequence.
+
+    Shared between the parser (when applying env defaults) and the
+    config-emit code (when materialising env vars during a dump walk).
+    """
+    nargs = argument.nargs
+    if nargs in (Nargs.ONE_OR_MORE, Nargs.ZERO_OR_MORE, "*", "+"):
+        return True
+    return isinstance(nargs, int) and nargs >= 1
+
+
+def coerce_env_default(raw: Any, argument: Any) -> Any:
+    """Coerce a raw env-var string into the value argparse would bind.
+
+    Mirrors the conversions ``Parser._add_argument`` applies after
+    reading ``os.getenv``: ``ast.literal_eval`` for sequence-typed
+    arguments, :func:`parse_bool` for ``store_true``/``store_false``
+    actions, and ``argument.type`` for the scalar fallback.
+
+    Single source of truth for both the parser's env binding and the
+    dump-time field walker; using it in both places keeps the two
+    paths from drifting apart.
+    """
+    if not isinstance(raw, str):
+        return raw
+    if raw and nargs_is_list(argument):
+        try:
+            return list(
+                map(argument.type or str, ast.literal_eval(raw)),
+            )
+        except Exception:
+            return raw
+    if argument.action in (
+        Actions.STORE_TRUE,
+        Actions.STORE_FALSE,
+        "store_true",
+        "store_false",
+    ):
+        return parse_bool(raw)
+    type_func = argument.type
+    if type_func is None:
+        return raw
+    try:
+        already_correct = isinstance(raw, type_func)
+    except TypeError:
+        already_correct = False
+    if already_correct:
+        return raw
+    try:
+        return type_func(raw)
+    except Exception:
+        return raw
 
 
 def _is_union_type(typespec: Any) -> bool:

--- a/docs/api.md
+++ b/docs/api.md
@@ -645,6 +645,18 @@ for the user guide.
    :members:
 ```
 
+### ConfigField
+
+The record type that custom ``render`` implementations consume. One
+``ConfigField`` is yielded per leaf argument in the parser tree,
+carrying everything a renderer needs (path, dest, value, env var,
+help) so subclasses never have to walk the tree themselves.
+
+```{eval-rst}
+.. autoclass:: argclass.ConfigField
+   :members:
+```
+
 ### INIConfigGenerator
 
 ```{eval-rst}

--- a/docs/api.md
+++ b/docs/api.md
@@ -631,3 +631,56 @@ assert app.level == Level.DEBUG
 ```{eval-rst}
 .. autofunction:: argclass.EnumArgument
 ```
+
+## Config Generation
+
+Classes for writing config files from a parser (the inverse of
+`config_files=` reading). See [Generating Config Files](config-generation.md)
+for the user guide.
+
+### ConfigGenerator
+
+```{eval-rst}
+.. autoclass:: argclass.ConfigGenerator
+   :members:
+```
+
+### INIConfigGenerator
+
+```{eval-rst}
+.. autoclass:: argclass.INIConfigGenerator
+   :members:
+```
+
+### JSONConfigGenerator
+
+```{eval-rst}
+.. autoclass:: argclass.JSONConfigGenerator
+   :members:
+```
+
+### TOMLConfigGenerator
+
+```{eval-rst}
+.. autoclass:: argclass.TOMLConfigGenerator
+   :members:
+```
+
+### EnvConfigGenerator
+
+```{eval-rst}
+.. autoclass:: argclass.EnvConfigGenerator
+   :members:
+```
+
+### GenerateConfigAction
+
+```{eval-rst}
+.. autoclass:: argclass.GenerateConfigAction
+```
+
+### NonConfigAction
+
+```{eval-rst}
+.. autoclass:: argclass.NonConfigAction
+```

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -683,3 +683,9 @@ Run `python myapp.py --check-updates` to see the live PyPI check.
 The pattern generalises to any custom action: declare your own constructor
 parameters, consume them in `__init__` before calling `super().__init__`,
 and pass them through `argclass.Argument(action=YourAction, your_param=...)`.
+
+The same passthrough drives argclass's built-in `GenerateConfigAction`,
+which takes a `generator=` kwarg and dumps the current parser state to a
+file (or stdout). For "fire and exit" actions that should not appear in
+generated configs, inherit from `NonConfigAction`. See [Generating
+Config Files](config-generation.md) for the full guide.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -686,6 +686,40 @@ and pass them through `argclass.Argument(action=YourAction, your_param=...)`.
 
 The same passthrough drives argclass's built-in `GenerateConfigAction`,
 which takes a `generator=` kwarg and dumps the current parser state to a
-file (or stdout). For "fire and exit" actions that should not appear in
-generated configs, inherit from `NonConfigAction`. See [Generating
-Config Files](config-generation.md) for the full guide.
+file (or stdout). See [Generating Config Files](config-generation.md) for
+the full guide.
+
+### Custom Actions and config generation
+
+If your custom action is the "fire and exit" kind — `--version`,
+`--check-updates`, `--health`, anything that prints something and calls
+`parser.exit()` — argclass's config generators must skip it from dumps.
+Otherwise it would end up as a noisy empty entry. Two equivalent opt-outs:
+
+1. **Inherit from `argclass.NonConfigAction`** — cleanest if you're
+   defining a new action from scratch. The base class just sets the
+   `__emit_config__ = False` marker.
+
+2. **Set `__emit_config__ = False` on the action class directly** —
+   useful if you already inherit from something else (a third-party
+   action, your own base).
+
+```python
+import argparse, argclass
+
+# Option 1: subclass NonConfigAction.
+class CheckUpdatesAction(argclass.NonConfigAction):
+    ...
+
+# Option 2: mark an existing action class.
+class CheckUpdatesAction(argparse.Action):
+    __emit_config__ = False
+    ...
+```
+
+argclass's built-in `--help` and `--version` (`Actions.HELP` /
+`Actions.VERSION`) are recognised automatically and skipped without
+either marker. Stateful custom actions (counters, accumulators, etc.)
+are kept in dumps — only "fire and exit" style actions need to opt out.
+See [Excluding arguments from dumps](config-generation.md#excluding-arguments-from-dumps)
+for the full discussion.

--- a/docs/config-generation.md
+++ b/docs/config-generation.md
@@ -7,8 +7,10 @@ parsed state for debugging, or hand a snapshot off to other tools.
 
 ## How it works
 
-A `ConfigGenerator` walks the parser tree, builds a nested dict of
-the current state, then renders it to a format-specific string.
+A `ConfigGenerator` walks the parser tree once and yields
+`ConfigField` records containing the current value, attribute path,
+help text, and env var metadata. Generators render that field stream
+to a format-specific string.
 argclass ships four generators:
 
 | Class                  | Output  |
@@ -18,9 +20,8 @@ argclass ships four generators:
 | `TOMLConfigGenerator`  | TOML    |
 | `EnvConfigGenerator`   | `.env`  |
 
-All inherit the same walking + Action wiring; subclasses only
-override `render(data, help_map)` (or `dump_to_string(parser)` for
-formats that need extra metadata such as env var names).
+All inherit the same walking + Action wiring; subclasses override
+`render(fields)`.
 
 ## Basic usage
 
@@ -504,9 +505,8 @@ assert "host=localhost" in text
 assert "port=8080" in text
 ```
 
-For formats that need extra metadata (like env var names), override
-`dump_to_string(parser)` directly — `EnvConfigGenerator` is the
-reference example.
+Field records already include metadata such as env var names, so even
+formats like `.env` can usually implement only `render(fields)`.
 
 ## Security note
 

--- a/docs/config-generation.md
+++ b/docs/config-generation.md
@@ -478,29 +478,22 @@ Subclass `ConfigGenerator` and override `render`:
 <!--- name: test_config_gen_custom --->
 ```python
 import argclass
-from typing import Any, Dict, Optional
-from argclass.emit import HelpMap
+from argclass.emit import ConfigField
+from typing import Iterable
 
 class KeyValueGenerator(argclass.ConfigGenerator):
     """Flat KEY=VALUE format with dotted paths for nested groups."""
 
     extension = ".kv"
 
-    def render(
-        self,
-        data: Dict[str, Any],
-        help_map: Optional[HelpMap] = None,
-    ) -> str:
+    def render(self, fields: Iterable[ConfigField]) -> str:
         lines = []
-        self._walk(data, (), lines)
+        for field in fields:
+            if field.value is None:
+                continue
+            key = ".".join(field.attr_path)
+            lines.append(f"{key}={field.value}")
         return "\n".join(lines) + "\n"
-
-    def _walk(self, data, path, lines):
-        for key, value in data.items():
-            if isinstance(value, dict):
-                self._walk(value, path + (key,), lines)
-            else:
-                lines.append(f"{'.'.join(path + (key,))}={value}")
 
 class CLI(argclass.Parser):
     host: str = "localhost"

--- a/docs/config-generation.md
+++ b/docs/config-generation.md
@@ -1,0 +1,276 @@
+# Generating Config Files
+
+argclass can WRITE config files for a parser, the inverse of the
+config-file reading covered in [Config Files](config-files.md).
+Use this to scaffold sample configs for users, dump the current
+parsed state for debugging, or hand a snapshot off to other tools.
+
+## How it works
+
+A `ConfigGenerator` walks the parser tree, builds a nested dict of
+the current state, then renders it to a format-specific string.
+argclass ships four generators:
+
+| Class                  | Output  |
+|------------------------|---------|
+| `INIConfigGenerator`   | INI     |
+| `JSONConfigGenerator`  | JSON    |
+| `TOMLConfigGenerator`  | TOML    |
+| `EnvConfigGenerator`   | `.env`  |
+
+All inherit the same walking + Action wiring; subclasses only
+override `render(data, help_map)` (or `dump_to_string(parser)` for
+formats that need extra metadata such as env var names).
+
+## Basic usage
+
+<!--- name: test_config_gen_basic --->
+```python
+import argclass
+
+class Database(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+
+class CLI(argclass.Parser):
+    debug: bool = False
+    name: str = argclass.Argument(default="app", help="App name")
+    db: Database = Database()
+
+parser = CLI()
+ini_text = argclass.INIConfigGenerator().dump_to_string(parser)
+assert "[DEFAULT]" in ini_text
+assert "name = app" in ini_text
+assert "[db]" in ini_text
+assert "host = localhost" in ini_text
+```
+
+## Writing to a file (or stdout)
+
+`dump(parser, dest)` accepts a path, a file-like object, or `"-"`
+for stdout:
+
+<!--- name: test_config_gen_dump_file --->
+```python
+import argclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+
+with NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+    config_path = f.name
+
+argclass.TOMLConfigGenerator().dump(CLI(), config_path)
+
+# Read it back
+loaded = CLI(
+    config_files=[config_path],
+    config_parser_class=argclass.TOMLDefaultsParser,
+)
+loaded.parse_args([])
+assert loaded.host == "localhost"
+assert loaded.port == 8080
+
+Path(config_path).unlink()
+```
+
+## The `--generate-config` flag
+
+argclass ships `GenerateConfigAction` — an argparse Action that lets
+users dump a config from your CLI:
+
+```python
+import argclass
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+    generate = argclass.Argument(
+        "--generate-config",
+        action=argclass.GenerateConfigAction,
+        generator=argclass.INIConfigGenerator,
+        metavar="FILE",
+    )
+```
+
+End users run:
+
+```
+myapp --generate-config /etc/myapp.ini   # write a file
+myapp --generate-config -                # print to stdout
+```
+
+The action writes the file (or stdout), then exits with status 0.
+
+You can also pass a generator INSTANCE instead of a class — useful
+if your generator needs constructor arguments:
+
+```python
+generator=argclass.JSONConfigGenerator()
+```
+
+## Sources reflected in the dump
+
+The generator reads the parser's CURRENT state. Whatever argclass
+resolved at the moment of dumping is what gets written — defaults,
+config-file values, env vars, or CLI overrides. The usual priority
+order (`defaults < config < env < CLI`) is preserved, so dumping
+after `parse_args` gives you a full snapshot.
+
+<!--- name: test_config_gen_cli_in_dump --->
+```python
+import argclass
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+
+parser = CLI()
+parser.parse_args(["--host", "10.0.0.1", "--port", "9090"])
+
+text = argclass.INIConfigGenerator().dump_to_string(parser)
+assert "host = 10.0.0.1" in text
+assert "port = 9090" in text
+```
+
+## Generating env-var listings
+
+`EnvConfigGenerator` emits a `.env`-style listing — one
+`KEY=value` line per argument, using the env var name argclass
+would read (explicit `env_var=` or computed from
+`auto_env_var_prefix=`). Arguments without a resolvable env var are
+skipped — set `auto_env_var_prefix=` on the parser to get full
+coverage.
+
+<!--- name: test_config_gen_env --->
+```python
+import argclass
+
+class Database(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+
+class CLI(argclass.Parser):
+    debug: bool = False
+    db: Database = Database()
+
+parser = CLI(auto_env_var_prefix="APP_")
+text = argclass.EnvConfigGenerator().dump_to_string(parser)
+assert "APP_DEBUG=false" in text
+assert "APP_DB_HOST=localhost" in text
+assert "APP_DB_PORT=5432" in text
+```
+
+Lists are emitted as Python literal syntax so argclass can read them
+back via `ast.literal_eval`:
+
+```
+APP_TAGS=['alpha', 'beta', 'gamma']
+```
+
+Strings are quoted only when they contain whitespace, `=`, `#`, or
+other characters that would confuse a typical `.env` parser.
+
+## Excluding arguments from dumps
+
+Some arguments make no sense in a config file — `--version`,
+`--generate-config` itself, `--check-updates`, anything else that
+"fires and exits". Mark such actions with `NonConfigAction`:
+
+<!--- name: test_config_gen_non_config_action --->
+```python
+import argparse
+import argclass
+
+class PingAction(argclass.NonConfigAction):
+    def __init__(self, option_strings, dest, **kw):
+        kw.setdefault("nargs", 0)
+        kw.setdefault("default", argparse.SUPPRESS)
+        super().__init__(option_strings, dest, **kw)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.exit(0, "pong\n")
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    ping = argclass.Argument(action=PingAction)
+
+text = argclass.INIConfigGenerator().dump_to_string(CLI())
+assert "host = localhost" in text
+assert "ping" not in text
+```
+
+argparse's built-in `--help` and `--version` actions are recognised
+and skipped automatically. Custom actions opt out via the marker
+class (or by setting `__emit_config__ = False` directly).
+
+## Custom formats
+
+Subclass `ConfigGenerator` and override `render`:
+
+<!--- name: test_config_gen_custom --->
+```python
+import argclass
+from typing import Any, Dict, Optional
+from argclass.emit import HelpMap
+
+class KeyValueGenerator(argclass.ConfigGenerator):
+    """Flat KEY=VALUE format with dotted paths for nested groups."""
+
+    extension = ".kv"
+
+    def render(
+        self,
+        data: Dict[str, Any],
+        help_map: Optional[HelpMap] = None,
+    ) -> str:
+        lines = []
+        self._walk(data, (), lines)
+        return "\n".join(lines) + "\n"
+
+    def _walk(self, data, path, lines):
+        for key, value in data.items():
+            if isinstance(value, dict):
+                self._walk(value, path + (key,), lines)
+            else:
+                lines.append(f"{'.'.join(path + (key,))}={value}")
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+
+text = KeyValueGenerator().dump_to_string(CLI())
+assert "host=localhost" in text
+assert "port=8080" in text
+```
+
+For formats that need extra metadata (like env var names), override
+`dump_to_string(parser)` directly — `EnvConfigGenerator` is the
+reference example.
+
+## Security note
+
+Generators emit values as-is, including those marked
+[`Secret()`](secrets.md). A dumped config can therefore contain
+credentials. Treat the output file like any credential-bearing file:
+
+- Set restrictive permissions when writing to disk.
+- Avoid dumping to shared locations or sending to stdout in
+  contexts where logs may be captured.
+- Prefer the `EnvConfigGenerator` form when you want to record
+  config in a way that's easy to load via a secret-manager wrapper.
+
+## Limitations
+
+- **Subparsers are skipped.** Subparsers represent runtime branches,
+  not config-time state. Mixing them into one file blurs the model.
+  Each subparser can be dumped separately by passing the subparser
+  instance to the generator.
+- **JSON has no comments.** Help text is dropped in JSON output;
+  INI, TOML, and `.env` formats include it.
+- **TOML is emitted by a minimal hand-rolled writer.** It covers
+  the types argclass supports (`str`, `int`, `float`, `bool`,
+  `list`, `None`). Exotic values fall back to `str()`.

--- a/docs/config-generation.md
+++ b/docs/config-generation.md
@@ -120,6 +120,22 @@ config-file values, env vars, or CLI overrides. The usual priority
 order (`defaults < config < env < CLI`) is preserved, so dumping
 after `parse_args` gives you a full snapshot.
 
+This makes config generation useful for more than just scaffolding
+defaults — you can also use it to:
+
+- **Convert between formats.** Load an existing INI, dump as TOML.
+- **Snapshot a deployed configuration.** After `parse_args`, dump to
+  inspect what the parser actually resolved (defaults plus
+  config file plus env vars plus CLI).
+- **Materialise env-based config to a file.** Run the parser with
+  env vars set, dump as INI/TOML/JSON, commit the file.
+
+### Including CLI values
+
+CLI arguments parsed by `parse_args` end up in the dump. After parse,
+the parser's attributes carry the resolved values; dumping just reads
+them out.
+
 <!--- name: test_config_gen_cli_in_dump --->
 ```python
 import argclass
@@ -135,6 +151,211 @@ text = argclass.INIConfigGenerator().dump_to_string(parser)
 assert "host = 10.0.0.1" in text
 assert "port = 9090" in text
 ```
+
+When `--generate-config` is invoked via `GenerateConfigAction`, the
+action also captures CLI arguments that argparse has already
+processed at that point in the command line — order matters. Put
+overrides BEFORE the generation flag to make sure they reach the
+dump.
+
+### Including existing config-file values
+
+A parser configured with `config_files=` loads those values during
+`parse_args`. Dump after parse and the source config-file values
+appear in the output, which makes converting between formats
+trivial:
+
+<!--- name: test_config_gen_format_conversion --->
+```python
+import argclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+
+# Pretend the user already ships an INI; convert it to TOML.
+with NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+    f.write("[DEFAULT]\nhost = prod.example.com\nport = 9000\n")
+    src = f.name
+
+parser = CLI(config_files=[src])
+parser.parse_args([])
+toml_text = argclass.TOMLConfigGenerator().dump_to_string(parser)
+
+assert 'host = "prod.example.com"' in toml_text
+assert "port = 9000" in toml_text
+
+Path(src).unlink()
+```
+
+### Including environment variables
+
+When `auto_env_var_prefix=` is set on the parser (or arguments
+declare explicit `env_var=`), values from `os.environ` are resolved
+just like config or CLI values, and they land in the dump too.
+
+<!--- name: test_config_gen_env_in_dump --->
+```python
+import os
+import argclass
+
+os.environ["APP_HOST"] = "from-env.example.com"
+os.environ["APP_PORT"] = "9999"
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+
+parser = CLI(auto_env_var_prefix="APP_")
+parser.parse_args([])
+
+ini = argclass.INIConfigGenerator().dump_to_string(parser)
+assert "host = from-env.example.com" in ini
+assert "port = 9999" in ini
+
+del os.environ["APP_HOST"]
+del os.environ["APP_PORT"]
+```
+
+The same env-aware behaviour kicks in when the dump runs from
+`GenerateConfigAction` mid-parse (i.e. when the user passes
+`--generate-config -` on the command line). `os.environ` is consulted
+directly at dump time, so you don't need to call `parse_args([])`
+first.
+
+## Migrating between config formats
+
+A common need: an app already ships an INI config and you want to
+move to TOML (or JSON, or `.env`). Because the same parser class
+reads with `AbstractDefaultsParser` and writes with
+`ConfigGenerator`, conversion is "load with reader X, dump with
+generator Y". The values flow through your typed schema, so the
+result is structurally identical even if the syntax changes.
+
+Three ways to do it, depending on context.
+
+### One-shot script (recommended for migration)
+
+Write a small Python script that uses your real parser class. This
+catches schema mismatches — if a key in the source config has no
+corresponding argument, you'll see it (it's dropped from the dump).
+
+<!--- name: test_config_gen_migrate_oneshot --->
+```python
+import argclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+class Database(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+
+class App(argclass.Parser):
+    debug: bool = False
+    name: str = "myapp"
+    db: Database = Database()
+
+# Existing INI (in real life: shipped with the app).
+with NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+    f.write(
+        "[DEFAULT]\n"
+        "debug = true\n"
+        "name = prod\n"
+        "\n"
+        "[db]\n"
+        "host = db.prod.example.com\n"
+        "port = 6432\n",
+    )
+    ini_path = f.name
+
+# Load the existing INI through the same parser class.
+parser = App(config_files=[ini_path])
+parser.parse_args([])
+
+# Dump as TOML.
+toml_path = Path(ini_path).with_suffix(".toml")
+argclass.TOMLConfigGenerator().dump(parser, str(toml_path))
+
+# Sanity-check: read the new TOML back through the same parser
+# and confirm we got the same resolved state.
+reloaded = App(
+    config_files=[str(toml_path)],
+    config_parser_class=argclass.TOMLDefaultsParser,
+)
+reloaded.parse_args([])
+assert reloaded.debug is True
+assert reloaded.name == "prod"
+assert reloaded.db.host == "db.prod.example.com"
+assert reloaded.db.port == 6432
+
+Path(ini_path).unlink()
+toml_path.unlink()
+```
+
+This approach is the one to ship in a release note ("run
+`python -m myapp.migrate config.ini`") — users get a deterministic,
+schema-validated conversion. Add a `--dry-run` flag that prints to
+stdout instead of writing if you want to be polite.
+
+### Mid-flight conversion via `--generate-config`
+
+If your app already wires `GenerateConfigAction` (see the
+"`--generate-config` flag" section above) and reads `config_files=`,
+users can convert in a single command without any extra script:
+
+```
+# Read the old INI, write the new TOML, exit.
+myapp --config /etc/myapp.ini --generate-toml /etc/myapp.toml
+
+# Inspect first by streaming to stdout.
+myapp --config /etc/myapp.ini --generate-toml -
+```
+
+The Action runs after argparse has applied env vars and
+config-file values to the namespace, so the dump captures the
+full resolved state — including any CLI overrides the user typed
+before `--generate-toml`.
+
+### Bulk conversion with `tmp_path` / pipelines
+
+For converting many files (e.g. as part of a release migration
+script), wrap the one-shot pattern in a loop. Stream straight to
+the target file with `dump(parser, dest)` to keep memory flat:
+
+```python
+import argclass
+from pathlib import Path
+
+for src in Path("configs").glob("*.ini"):
+    parser = App(config_files=[src])
+    parser.parse_args([])
+    dst = src.with_suffix(".toml")
+    argclass.TOMLConfigGenerator().dump(parser, str(dst))
+```
+
+### Choosing the target format
+
+| If you want…                         | Pick                  |
+|--------------------------------------|-----------------------|
+| Comments + nested sections           | TOML                  |
+| Stdlib-only, simplest legacy fit     | INI                   |
+| Programmatic post-processing         | JSON                  |
+| `.env` for Docker / systemd / CI     | `EnvConfigGenerator`  |
+
+Notes:
+
+- JSON has no comments — your help text will be lost. INI, TOML,
+  and `.env` preserve it as `;`/`#` comment lines.
+- Secrets are emitted as plain values (see the "Security note"
+  section below). When converting, write the new file
+  with restrictive permissions and delete the source if it
+  contained credentials.
+- Subparsers aren't included in the dump. If your CLI has
+  subcommands with their own config-relevant args, dump each
+  subparser separately (pass the subparser instance to the
+  generator).
 
 ## Generating env-var listings
 

--- a/docs/config-generation.md
+++ b/docs/config-generation.md
@@ -479,15 +479,14 @@ Subclass `ConfigGenerator` and override `render`:
 <!--- name: test_config_gen_custom --->
 ```python
 import argclass
-from argclass.emit import ConfigField
-from typing import Iterable
+from typing import Sequence
 
 class KeyValueGenerator(argclass.ConfigGenerator):
     """Flat KEY=VALUE format with dotted paths for nested groups."""
 
     extension = ".kv"
 
-    def render(self, fields: Iterable[ConfigField]) -> str:
+    def render(self, fields: Sequence[argclass.ConfigField]) -> str:
         lines = []
         for field in fields:
             if field.value is None:

--- a/docs/config-generation.md
+++ b/docs/config-generation.md
@@ -399,7 +399,19 @@ other characters that would confuse a typical `.env` parser.
 
 Some arguments make no sense in a config file — `--version`,
 `--generate-config` itself, `--check-updates`, anything else that
-"fires and exits". Mark such actions with `NonConfigAction`:
+"fires and exits". argclass needs to know about them so they stay
+out of generated configs.
+
+argparse's built-in `--help` and `--version` actions are recognised
+and skipped automatically. For your own custom `argparse.Action`
+subclasses, pick one of two equivalent opt-outs:
+
+### Option 1 — inherit from `argclass.NonConfigAction`
+
+The cleanest choice if you're writing a new action from scratch.
+`NonConfigAction` is a thin `argparse.Action` subclass that just
+sets the `__emit_config__ = False` marker for you, and it keeps
+intent visible at the class declaration:
 
 <!--- name: test_config_gen_non_config_action --->
 ```python
@@ -424,9 +436,40 @@ assert "host = localhost" in text
 assert "ping" not in text
 ```
 
-argparse's built-in `--help` and `--version` actions are recognised
-and skipped automatically. Custom actions opt out via the marker
-class (or by setting `__emit_config__ = False` directly).
+### Option 2 — set `__emit_config__ = False` on an existing action
+
+Useful when you already inherit from something else (a third-party
+`argparse.Action` subclass, your own base, etc.) and would rather not
+add another base class. The marker is just a class attribute:
+
+<!--- name: test_config_gen_marker_attribute --->
+```python
+import argparse
+import argclass
+
+class PingAction(argparse.Action):
+    __emit_config__ = False   # opt out, equivalent to NonConfigAction
+
+    def __init__(self, option_strings, dest, **kw):
+        kw.setdefault("nargs", 0)
+        kw.setdefault("default", argparse.SUPPRESS)
+        super().__init__(option_strings, dest, **kw)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.exit(0, "pong\n")
+
+class CLI(argclass.Parser):
+    host: str = "localhost"
+    ping = argclass.Argument(action=PingAction)
+
+text = argclass.INIConfigGenerator().dump_to_string(CLI())
+assert "ping" not in text
+```
+
+Both forms are honoured by the generator the same way — pick
+whichever fits your inheritance chain. If you forget both, your
+action will end up in dumps as an empty value, which is what tells
+you to opt out.
 
 ## Custom formats
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -499,6 +499,7 @@ arguments
 groups
 subparsers
 config-files
+config-generation
 environment
 secrets
 security

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,7 @@ content extraction.
 - [Groups](https://docs.argclass.com/_sources/groups.md.txt): Reusable argument groups with prefix support
 - [Subparsers](https://docs.argclass.com/_sources/subparsers.md.txt): Hierarchical subcommands and nested parsers
 - [Config Files](https://docs.argclass.com/_sources/config-files.md.txt): INI, JSON, and TOML configuration file support
+- [Generating Config Files](https://docs.argclass.com/_sources/config-generation.md.txt): Writing INI/JSON/TOML/.env from a parser, the inverse of reading
 - [Environment Variables](https://docs.argclass.com/_sources/environment.md.txt): Automatic env var binding with prefixes
 - [Secrets](https://docs.argclass.com/_sources/secrets.md.txt): Secret masking to prevent accidental exposure in logs
 - [API Reference](https://docs.argclass.com/api.html): Full API documentation with all classes and functions
@@ -162,6 +163,36 @@ class CLI(argclass.Parser):
         search_paths=["/etc/myapp.ini", "~/.myapp.ini"],
     )
 ```
+
+### Generating config files (the inverse of reading)
+
+argclass can WRITE a config file from a Parser. Four built-in generators: `INIConfigGenerator`, `JSONConfigGenerator`, `TOMLConfigGenerator`, `EnvConfigGenerator` (the `.env`-style emitter uses each argument's env var name, computed from explicit `env_var=` or the parser's `auto_env_var_prefix`). Subclass `ConfigGenerator` to add new formats. `NonConfigAction` marks actions that should NOT appear in dumps (used internally by `GenerateConfigAction` and `Actions.VERSION` / `Actions.HELP`). Generators reflect the parser's current state, so dumping after `parse_args` snapshots resolved values (defaults < config < env < CLI).
+
+```python
+import argclass
+
+class Database(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+
+class CLI(argclass.Parser):
+    debug: bool = False
+    db: Database = Database()
+    # Built-in argparse Action: --generate-config FILE (or - for stdout)
+    generate = argclass.Argument(
+        "--generate-config",
+        action=argclass.GenerateConfigAction,
+        generator=argclass.INIConfigGenerator,
+    )
+
+# Programmatic
+print(argclass.INIConfigGenerator().dump_to_string(CLI()))
+print(argclass.EnvConfigGenerator().dump_to_string(
+    CLI(auto_env_var_prefix="APP_"),
+))
+```
+
+Notes for users: secrets are emitted as-is (treat the output like a credential file); subparsers are skipped; JSON has no comments (help text is dropped there). See https://docs.argclass.com/config-generation.html for the full guide.
 
 ### Argparse passthrough kwargs
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -192,7 +192,7 @@ print(argclass.EnvConfigGenerator().dump_to_string(
 ))
 ```
 
-Notes for users: secrets are emitted as-is (treat the output like a credential file); subparsers are skipped; JSON has no comments (help text is dropped there). See https://docs.argclass.com/config-generation.html for the full guide.
+Notes for users: secrets are emitted as-is (treat the output like a credential file); subparsers are skipped; JSON has no comments (help text is dropped there). Dumps reflect the parser's CURRENT state, so they pick up values from `config_files=`, env vars (explicit `env_var=` or `auto_env_var_prefix=`), and CLI args. This makes generation useful for format conversion (load INI, dump TOML), snapshotting a live config, or materialising env-based config to a file. See https://docs.argclass.com/config-generation.html for the full guide.
 
 ### Argparse passthrough kwargs
 

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -15,22 +15,24 @@ import argparse
 import io
 import json
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, List, Optional, Type
 
 import pytest
 
 import argclass
 from argclass.emit import (
+    ConfigField,
     ConfigGenerator,
     EnvConfigGenerator,
     GenerateConfigAction,
-    HelpMap,
     INIConfigGenerator,
     JSONConfigGenerator,
     NonConfigAction,
     TOMLConfigGenerator,
     current_value,
     derive_env_var,
+    iter_config_fields,
+    normalize_value,
     should_emit,
 )
 
@@ -376,27 +378,15 @@ class TestCustomGenerator:
         class KeyValueGenerator(ConfigGenerator):
             extension = ".kv"
 
-            def render(
-                self,
-                data: Dict[str, Any],
-                help_map: Optional[HelpMap] = None,
-            ) -> str:
+            def render(self, fields) -> str:
                 lines: List[str] = []
-                self.walk(data, (), lines)
+                for field in fields:
+                    if field.value is None:
+                        continue
+                    lines.append(
+                        f"{'.'.join(field.attr_path)}={field.value}",
+                    )
                 return "\n".join(lines) + "\n"
-
-            def walk(
-                self,
-                data: Dict[str, Any],
-                path: tuple,
-                lines: List[str],
-            ) -> None:
-                for key, value in data.items():
-                    if isinstance(value, dict):
-                        self.walk(value, path + (key,), lines)
-                    else:
-                        full_key = ".".join(path + (key,))
-                        lines.append(f"{full_key}={value}")
 
         CLI = make_cli()
         out = tmp_path / "cfg.kv"
@@ -915,10 +905,10 @@ class TestEnvConfigGenerator:
         assert gen.render_value("has spaces") == '"has spaces"'
         assert gen.render_value('has "quote"') == r'"has \"quote\""'
 
-    def test_render_raises_when_called_without_env_metadata(self):
-        gen = EnvConfigGenerator()
-        with pytest.raises(NotImplementedError):
-            gen.render({})
+    def test_render_empty_fields_returns_empty(self):
+        """``render([])`` is a valid call now — every subclass
+        honours the same ``Iterable[ConfigField]`` contract."""
+        assert EnvConfigGenerator().render([]) == ""
 
     def test_action_wires_env_generator(self, tmp_path: Path):
         class App(argclass.Parser):
@@ -978,7 +968,16 @@ class TestEnvIntrospection:
         arg = argclass.TypedArgument()
         assert derive_env_var(None, "host", arg) is None
 
-    def test_build_env_map_with_prefix_override(self):
+    def env_map_from_fields(self, parser: argclass.Parser) -> dict:
+        """Build {attr_path: env_var} by walking ConfigField stream
+        — exercises the new single-walk introspection contract."""
+        return {
+            f.attr_path: f.env_var
+            for f in iter_config_fields(parser)
+            if f.env_var
+        }
+
+    def test_iter_fields_with_prefix_override(self):
         """Group(prefix=...) overrides the env-var path segment."""
 
         class Inner(argclass.Group):
@@ -988,10 +987,10 @@ class TestEnvIntrospection:
             inner: Inner = Inner(prefix="i")
 
         p = App(auto_env_var_prefix="APP_")
-        env_map = EnvConfigGenerator().build_env_map(p)
+        env_map = self.env_map_from_fields(p)
         assert env_map[("inner", "value")] == "APP_I_VALUE"
 
-    def test_build_env_map_with_empty_prefix(self):
+    def test_iter_fields_with_empty_prefix(self):
         class Inner(argclass.Group):
             value: str = "x"
 
@@ -999,12 +998,12 @@ class TestEnvIntrospection:
             inner: Inner = Inner(prefix="")
 
         p = App(auto_env_var_prefix="APP_")
-        env_map = EnvConfigGenerator().build_env_map(p)
+        env_map = self.env_map_from_fields(p)
         assert env_map[("inner", "value")] == "APP_VALUE"
 
     def test_nested_group_skips_non_config_action(self):
         """NonConfigAction marker on an arg inside a nested group
-        keeps it out of the env_map too."""
+        keeps it out of the field stream too."""
 
         class MetaAction(NonConfigAction):
             def __init__(self, option_strings, dest, **kw):
@@ -1022,15 +1021,18 @@ class TestEnvIntrospection:
         class App(argclass.Parser):
             inner: Inner = Inner()
 
-        env_map = EnvConfigGenerator().build_env_map(
-            App(auto_env_var_prefix="APP_"),
-        )
-        assert ("inner", "host") in env_map
-        assert ("inner", "meta") not in env_map
+        paths = {
+            f.attr_path
+            for f in iter_config_fields(
+                App(auto_env_var_prefix="APP_"),
+            )
+        }
+        assert ("inner", "host") in paths
+        assert ("inner", "meta") not in paths
 
     def test_nested_group_skips_arg_without_resolvable_env(self):
         """No auto_env_var_prefix AND no explicit env_var on an arg
-        inside a group — that arg is absent from the env_map."""
+        inside a group — that arg has no env_var in the field stream."""
 
         class Inner(argclass.Group):
             quiet: str = "yes"
@@ -1042,7 +1044,7 @@ class TestEnvIntrospection:
         class App(argclass.Parser):
             inner: Inner = Inner()
 
-        env_map = EnvConfigGenerator().build_env_map(App())
+        env_map = self.env_map_from_fields(App())
         assert env_map.get(("inner", "shouted")) == "SHOUTED"
         assert ("inner", "quiet") not in env_map
 
@@ -1062,6 +1064,172 @@ class TestEnvIntrospection:
 
     def test_quote_empty_string(self):
         assert EnvConfigGenerator().quote_string("") == ""
+
+
+class TestNormalizeValue:
+    """``normalize_value`` is the single round-trip-fix point used by
+    every generator — Enum/set/frozenset/Path all flow through it."""
+
+    def test_enum_member_returns_name(self):
+        from enum import Enum
+
+        class Color(Enum):
+            RED = "red"
+            GREEN = "green"
+
+        assert normalize_value(Color.RED) == "RED"
+
+    def test_int_enum_returns_name(self):
+        from enum import IntEnum
+
+        class Level(IntEnum):
+            INFO = 10
+            DEBUG = 20
+
+        assert normalize_value(Level.DEBUG) == "DEBUG"
+
+    def test_set_returns_sorted_list(self):
+        assert normalize_value({3, 1, 2}) == [1, 2, 3]
+
+    def test_frozenset_returns_sorted_list(self):
+        assert normalize_value(frozenset({"b", "a"})) == ["a", "b"]
+
+    def test_set_of_unorderable_returns_list(self):
+        """Mixed types fall back to unordered ``list``."""
+
+        class Opaque:
+            pass
+
+        items = {Opaque(), Opaque()}
+        out = normalize_value(items)
+        assert isinstance(out, list)
+        assert len(out) == 2
+
+    def test_path_returns_string(self):
+        from pathlib import PurePosixPath
+
+        assert normalize_value(PurePosixPath("/etc/app")) == "/etc/app"
+
+    def test_native_values_pass_through(self):
+        for value in ("s", 1, 1.5, True, False, None, [1, 2], (3, 4)):
+            assert normalize_value(value) == value
+
+
+class TestEnumAndCollectionRoundTrip:
+    """Round-trip Enum / set / frozenset through each format. These
+    used to silently break: ``Color.RED`` would be written as
+    ``"Color.RED"`` and ``frozenset({1, 2})`` as a non-sequence
+    string."""
+
+    @staticmethod
+    def make_parser() -> type:
+        from enum import Enum
+
+        class Color(Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        class App(argclass.Parser):
+            color: Color = argclass.EnumArgument(Color, default="GREEN")
+            unique: frozenset = argclass.Argument(  # type: ignore[type-arg]
+                type=int,
+                nargs=argclass.Nargs.ONE_OR_MORE,
+                converter=frozenset,
+                default=frozenset({1, 2, 3}),
+            )
+
+        App._Color = Color  # type: ignore[attr-defined]
+        return App
+
+    def test_enum_in_ini_roundtrip(self, tmp_path: Path):
+        App = self.make_parser()
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(App(), str(out))
+        loaded = App(config_files=[out])
+        loaded.parse_args([])
+        assert loaded.color.name == "GREEN"
+
+    def test_enum_in_toml_roundtrip(self, tmp_path: Path):
+        App = self.make_parser()
+        out = tmp_path / "cfg.toml"
+        TOMLConfigGenerator().dump(App(), str(out))
+        loaded = App(
+            config_files=[out],
+            config_parser_class=argclass.TOMLDefaultsParser,
+        )
+        loaded.parse_args([])
+        assert loaded.color.name == "GREEN"
+
+    def test_enum_in_json_roundtrip(self, tmp_path: Path):
+        App = self.make_parser()
+        out = tmp_path / "cfg.json"
+        JSONConfigGenerator().dump(App(), str(out))
+        loaded = App(
+            config_files=[out],
+            config_parser_class=argclass.JSONDefaultsParser,
+        )
+        loaded.parse_args([])
+        assert loaded.color.name == "GREEN"
+
+    def test_frozenset_dumps_as_sorted_list(self):
+        App = self.make_parser()
+        text = TOMLConfigGenerator().dump_to_string(App())
+        # Sorted list, not "frozenset({...})".
+        assert "unique = [1, 2, 3]" in text
+
+
+class TestFieldsToNestedDict:
+    """Direct tests on the field→dict helper used by JSON."""
+
+    @staticmethod
+    def make_field(attr_path: tuple, value: object) -> ConfigField:
+        return ConfigField(
+            attr_path=attr_path,
+            cli_path=attr_path,
+            dest="_".join(attr_path),
+            argument=argclass.TypedArgument(),
+            target=None,
+            value=value,
+            env_var=None,
+            help=None,
+        )
+
+    def test_skip_none_drops_keys(self):
+        from argclass.emit import fields_to_nested_dict
+
+        fields = [
+            self.make_field(("a",), 1),
+            self.make_field(("b",), None),
+            self.make_field(("g", "x"), None),
+            self.make_field(("g", "y"), 2),
+        ]
+        out = fields_to_nested_dict(fields, skip_none=True)
+        assert out == {"a": 1, "g": {"y": 2}}
+
+    def test_intermediate_non_dict_is_overwritten(self):
+        """Edge case: a field collides with a section name. The
+        helper recovers by replacing the leaf with a dict."""
+        from argclass.emit import fields_to_nested_dict
+
+        fields = [
+            self.make_field(("g",), "scalar"),
+            self.make_field(("g", "child"), 1),
+        ]
+        out = fields_to_nested_dict(fields)
+        assert out == {"g": {"child": 1}}
+
+
+class TestDumpAcceptsPath:
+    def test_dump_to_path_object(self, tmp_path: Path):
+        """``dump(parser, Path(...))`` must work, not just ``str``."""
+
+        class App(argclass.Parser):
+            host: str = "localhost"
+
+        path_obj = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(App(), path_obj)
+        assert path_obj.read_text().startswith("[DEFAULT]")
 
 
 class TestCrossFormatRoundTrip:

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1563,6 +1563,73 @@ class TestCoerceEnvValue:
         assert coerce_env_default(None, arg) is None
 
 
+class TestCurrentValueNamespacePriority:
+    """``current_value`` must prefer the supplied argparse namespace
+    over the instance ``__dict__``. Otherwise a parser that was
+    already parsed once would dump stale values when
+    ``GenerateConfigAction`` runs during a later parse."""
+
+    def test_namespace_overrides_stale_instance_dict(self):
+        """Simulate: parse once with host=old; reuse the parser and
+        parse again with host=new + --generate-config. The dump must
+        reflect 'new', not the stale 'old' on the instance."""
+        arg = argclass.TypedArgument(default="x")
+        target = type("Stub", (), {"__dict__": {"host": "old"}})()
+        ns = argparse.Namespace(host="new")
+        result = current_value(
+            target,
+            "host",
+            arg,
+            namespace=ns,
+            dest="host",
+        )
+        assert result == "new"
+
+    def test_namespace_absent_falls_back_to_instance_dict(self):
+        """Programmatic post-parse dump (no namespace) reads from
+        the instance state — that's the only place the parsed
+        values live."""
+        arg = argclass.TypedArgument(default="x")
+        target = type("Stub", (), {"__dict__": {"host": "parsed"}})()
+        assert current_value(target, "host", arg) == "parsed"
+
+
+class TestEnvStringEscaping:
+    """``.env`` files are line-oriented; any value with a literal
+    newline / CR / tab must be escaped, not emitted raw."""
+
+    def test_newline_escaped(self):
+        gen = EnvConfigGenerator()
+        assert gen.quote_string("a\nb") == r'"a\nb"'
+
+    def test_carriage_return_escaped(self):
+        gen = EnvConfigGenerator()
+        assert gen.quote_string("a\rb") == r'"a\rb"'
+
+    def test_tab_escaped(self):
+        gen = EnvConfigGenerator()
+        assert gen.quote_string("a\tb") == r'"a\tb"'
+
+    def test_dump_with_multiline_value_stays_one_line(self):
+        """End-to-end: env dump of a multi-line value must still
+        produce a single KEY=value line."""
+
+        class App(argclass.Parser):
+            banner: str = argclass.Argument(
+                default="line1\nline2",
+                env_var="BANNER",
+            )
+
+        text = EnvConfigGenerator().dump_to_string(App())
+        body_lines = [
+            line
+            for line in text.splitlines()
+            if line and not line.startswith("#")
+        ]
+        assert len(body_lines) == 1
+        assert body_lines[0] == r'BANNER="line1\nline2"'
+
+
 class TestDumpAcceptsPath:
     def test_dump_to_path_object(self, tmp_path: Path):
         """``dump(parser, Path(...))`` must work, not just ``str``."""

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -14,6 +14,7 @@ Covers:
 import argparse
 import io
 import json
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Type
 
@@ -29,6 +30,7 @@ from argclass.emit import (
     JSONConfigGenerator,
     NonConfigAction,
     TOMLConfigGenerator,
+    coerce_env_value,
     current_value,
     derive_env_var,
     iter_config_fields,
@@ -480,6 +482,22 @@ class TestHelpers:
         )
         assert result == "not-a-number"
 
+    def test_current_value_env_callable_type_conversion(self, monkeypatch):
+        """Callable ``type=`` values are converters, not isinstance
+        targets, so env fallback must call them without crashing."""
+        monkeypatch.setenv("APP_X", "5")
+        arg = argclass.TypedArgument(
+            type=lambda raw: int(raw) + 1,
+            default=0,
+        )
+        result = current_value(
+            type("Stub", (), {"__dict__": {}})(),
+            "x",
+            arg,
+            env_var="APP_X",
+        )
+        assert result == 6
+
     def test_current_value_reads_namespace_when_provided(self):
         ns = argparse.Namespace(host="from-cli")
         arg = argclass.TypedArgument(default="localhost")
@@ -744,6 +762,35 @@ class TestEdgeCases:
         text = INIConfigGenerator().dump_to_string(App())
         assert "ghost" not in text
         assert "present = yes" in text
+
+    def test_ini_default_section_does_not_leak_into_group_none_value(
+        self,
+        tmp_path: Path,
+    ):
+        """Round-trip with an INI [DEFAULT] / [inner] name collision.
+
+        The generated file omits ``inner.host`` because it is ``None``.
+        configparser would normally cascade the top-level ``host``
+        from [DEFAULT] into [inner], but
+        :class:`argclass.INIDefaultsParser` strips DEFAULT cascade so
+        each group's own None default survives.
+        """
+
+        class Inner(argclass.Group):
+            host: Optional[str] = None
+
+        class App(argclass.Parser):
+            host: str = "root"
+            inner: Inner = Inner()
+
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(App(), out)
+
+        loaded = App(config_files=[out])
+        loaded.parse_args([])
+
+        assert loaded.host == "root"
+        assert loaded.inner.host is None
 
     def test_ini_bool_value(self):
         gen = INIConfigGenerator()
@@ -1179,6 +1226,237 @@ class TestEnumAndCollectionRoundTrip:
         assert "unique = [1, 2, 3]" in text
 
 
+class TestGeneratorNormalisesIterablesToLists:
+    """The generators must convert set/frozenset/tuple to plain
+    ``list`` in every format. Otherwise the output is either invalid
+    syntax (TOML cannot represent ``frozenset(...)``) or unreadable
+    on round-trip (INI ``literal_eval`` rejects ``frozenset({1, 2})``,
+    JSON outright refuses sets).
+    """
+
+    @staticmethod
+    def make_parser_with_collections(default: Any) -> Type[argclass.Parser]:
+        class App(argclass.Parser):
+            tags: Any = argclass.Argument(
+                type=str,
+                nargs=argclass.Nargs.ONE_OR_MORE,
+                converter=type(default),
+                default=default,
+            )
+
+        return App
+
+    def test_set_dumps_as_list_in_all_formats(self, tmp_path: Path):
+        App = self.make_parser_with_collections({"c", "a", "b"})
+        for gen_cls in (
+            INIConfigGenerator,
+            JSONConfigGenerator,
+            TOMLConfigGenerator,
+        ):
+            text = gen_cls().dump_to_string(App())
+            assert "set(" not in text
+            assert "frozenset" not in text
+
+    def test_frozenset_dumps_as_list_in_all_formats(self, tmp_path: Path):
+        App = self.make_parser_with_collections(frozenset({3, 1, 2}))
+        for gen_cls in (
+            INIConfigGenerator,
+            JSONConfigGenerator,
+            TOMLConfigGenerator,
+        ):
+            text = gen_cls().dump_to_string(App())
+            assert "frozenset" not in text
+
+    def test_tuple_dumps_as_list_in_all_formats(self, tmp_path: Path):
+        """Tuples don't need normalisation per se — every emitter
+        already treats ``(list, tuple)`` uniformly — but pin the
+        observable behaviour so it can't regress."""
+
+        class App(argclass.Parser):
+            tags: tuple = argclass.Argument(  # type: ignore[type-arg]
+                type=str,
+                nargs=argclass.Nargs.ONE_OR_MORE,
+                converter=tuple,
+                default=("alpha", "beta"),
+            )
+
+        # JSON: list literal.
+        text = JSONConfigGenerator().dump_to_string(App())
+        assert '[\n    "alpha",\n    "beta"\n  ]' in text
+        # TOML: square-bracket array.
+        text = TOMLConfigGenerator().dump_to_string(App())
+        assert 'tags = ["alpha", "beta"]' in text
+        # INI: ast.literal_eval-able list.
+        text = INIConfigGenerator().dump_to_string(App())
+        assert "tags = ['alpha', 'beta']" in text
+
+
+class TestCrossFormatIterableRoundTrip:
+    """Per-format dump-and-reload for set / frozenset / tuple. Each
+    case loads through the parser class itself, so the dumped form
+    must be syntactically and semantically right for every format.
+    """
+
+    @staticmethod
+    def reload(
+        parser_cls: Type[argclass.Parser],
+        gen_cls: type,
+        defaults_cls: type,
+        tmp_path: Path,
+        ext: str,
+    ) -> argclass.Parser:
+        out = tmp_path / f"cfg.{ext}"
+        gen_cls().dump(parser_cls(), str(out))
+        loaded = parser_cls(
+            config_files=[out],
+            config_parser_class=defaults_cls,
+        )
+        loaded.parse_args([])
+        return loaded
+
+    @pytest.mark.parametrize(
+        "gen_cls,defaults_cls,ext",
+        [
+            (INIConfigGenerator, argclass.INIDefaultsParser, "ini"),
+            (JSONConfigGenerator, argclass.JSONDefaultsParser, "json"),
+            (TOMLConfigGenerator, argclass.TOMLDefaultsParser, "toml"),
+        ],
+    )
+    def test_set_round_trip(
+        self,
+        tmp_path: Path,
+        gen_cls: type,
+        defaults_cls: type,
+        ext: str,
+    ) -> None:
+        class App(argclass.Parser):
+            tags: Any = argclass.Argument(
+                type=str,
+                nargs=argclass.Nargs.ONE_OR_MORE,
+                converter=set,
+                default={"alpha", "beta", "gamma"},
+            )
+
+        loaded = self.reload(App, gen_cls, defaults_cls, tmp_path, ext)
+        assert loaded.tags == {"alpha", "beta", "gamma"}
+
+    @pytest.mark.parametrize(
+        "gen_cls,defaults_cls,ext",
+        [
+            (INIConfigGenerator, argclass.INIDefaultsParser, "ini"),
+            (JSONConfigGenerator, argclass.JSONDefaultsParser, "json"),
+            (TOMLConfigGenerator, argclass.TOMLDefaultsParser, "toml"),
+        ],
+    )
+    def test_frozenset_round_trip(
+        self,
+        tmp_path: Path,
+        gen_cls: type,
+        defaults_cls: type,
+        ext: str,
+    ) -> None:
+        class App(argclass.Parser):
+            tags: Any = argclass.Argument(
+                type=int,
+                nargs=argclass.Nargs.ONE_OR_MORE,
+                converter=frozenset,
+                default=frozenset({1, 2, 3}),
+            )
+
+        loaded = self.reload(App, gen_cls, defaults_cls, tmp_path, ext)
+        assert loaded.tags == frozenset({1, 2, 3})
+
+    @pytest.mark.parametrize(
+        "gen_cls,defaults_cls,ext",
+        [
+            (INIConfigGenerator, argclass.INIDefaultsParser, "ini"),
+            (JSONConfigGenerator, argclass.JSONDefaultsParser, "json"),
+            (TOMLConfigGenerator, argclass.TOMLDefaultsParser, "toml"),
+        ],
+    )
+    def test_enum_round_trip(
+        self,
+        tmp_path: Path,
+        gen_cls: type,
+        defaults_cls: type,
+        ext: str,
+    ) -> None:
+        class Color(Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        class App(argclass.Parser):
+            color: Color = argclass.EnumArgument(Color, default="GREEN")
+
+        loaded = self.reload(App, gen_cls, defaults_cls, tmp_path, ext)
+        assert loaded.color is Color.GREEN
+
+    @pytest.mark.parametrize(
+        "gen_cls,defaults_cls,ext",
+        [
+            (INIConfigGenerator, argclass.INIDefaultsParser, "ini"),
+            (JSONConfigGenerator, argclass.JSONDefaultsParser, "json"),
+            (TOMLConfigGenerator, argclass.TOMLDefaultsParser, "toml"),
+        ],
+    )
+    def test_enum_lowercase_round_trip(
+        self,
+        tmp_path: Path,
+        gen_cls: type,
+        defaults_cls: type,
+        ext: str,
+    ) -> None:
+        """``EnumArgument(lowercase=True)`` accepts both cases on
+        read; the dump emits canonical ``.name`` and the lenient
+        converter rehydrates it."""
+
+        class Color(Enum):
+            RED = "red"
+            BLUE = "blue"
+
+        class App(argclass.Parser):
+            color: Color = argclass.EnumArgument(
+                Color,
+                default="BLUE",
+                lowercase=True,
+            )
+
+        loaded = self.reload(App, gen_cls, defaults_cls, tmp_path, ext)
+        assert loaded.color is Color.BLUE
+
+    @pytest.mark.parametrize(
+        "gen_cls,defaults_cls,ext",
+        [
+            (INIConfigGenerator, argclass.INIDefaultsParser, "ini"),
+            (JSONConfigGenerator, argclass.JSONDefaultsParser, "json"),
+            (TOMLConfigGenerator, argclass.TOMLDefaultsParser, "toml"),
+        ],
+    )
+    def test_int_enum_round_trip(
+        self,
+        tmp_path: Path,
+        gen_cls: type,
+        defaults_cls: type,
+        ext: str,
+    ) -> None:
+        from enum import IntEnum
+
+        class Priority(IntEnum):
+            LOW = 1
+            MEDIUM = 5
+            HIGH = 10
+
+        class App(argclass.Parser):
+            level: Priority = argclass.EnumArgument(
+                Priority,
+                default="MEDIUM",
+            )
+
+        loaded = self.reload(App, gen_cls, defaults_cls, tmp_path, ext)
+        assert loaded.level is Priority.MEDIUM
+
+
 class TestFieldsToNestedDict:
     """Direct tests on the field→dict helper used by JSON."""
 
@@ -1218,6 +1496,63 @@ class TestFieldsToNestedDict:
         ]
         out = fields_to_nested_dict(fields)
         assert out == {"g": {"child": 1}}
+
+
+class TestCoerceEnvValue:
+    """``coerce_env_value`` mirrors argparse's env coercions so the
+    dump-mid-parse path sees parsed-style values instead of raw
+    strings. Each branch covered once."""
+
+    def test_list_via_literal_eval(self):
+        arg = argclass.TypedArgument(
+            type=int,
+            nargs=argclass.Nargs.ONE_OR_MORE,
+        )
+        assert coerce_env_value("[1, 2, 3]", arg) == [1, 2, 3]
+
+    def test_list_with_bad_literal_returns_raw(self):
+        arg = argclass.TypedArgument(
+            type=int,
+            nargs=argclass.Nargs.ONE_OR_MORE,
+        )
+        # Not parseable as a literal — return the raw string.
+        assert coerce_env_value("not-a-list", arg) == "not-a-list"
+
+    def test_bool_store_true_action(self):
+        arg = argclass.TypedArgument(action=argclass.Actions.STORE_TRUE)
+        assert coerce_env_value("true", arg) is True
+        assert coerce_env_value("0", arg) is False
+
+    def test_bool_store_false_string_action(self):
+        arg = argclass.TypedArgument(action="store_false")
+        assert coerce_env_value("yes", arg) is True
+
+    def test_no_type_returns_raw(self):
+        """Plain string-valued argument without ``type=`` passes the
+        env value through untouched."""
+        arg = argclass.TypedArgument()
+        assert coerce_env_value("hello", arg) == "hello"
+
+    def test_type_already_correct_returns_raw(self):
+        """``type=str`` plus a str env value short-circuits the
+        coercion (no redundant ``str("hello")`` call)."""
+        arg = argclass.TypedArgument(type=str)
+        assert coerce_env_value("hello", arg) == "hello"
+
+    def test_type_conversion_failure_returns_raw(self):
+        arg = argclass.TypedArgument(type=int)
+        assert coerce_env_value("not-an-int", arg) == "not-an-int"
+
+    def test_type_callable_not_a_class(self):
+        """A ``type=`` callable that is not itself a class (e.g.
+        a function) takes the ``isinstance(raw, type_func)`` path
+        through TypeError and falls back to calling it."""
+
+        def double(value: str) -> str:
+            return value + value
+
+        arg = argclass.TypedArgument(type=double)
+        assert coerce_env_value("ab", arg) == "abab"
 
 
 class TestDumpAcceptsPath:

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -30,13 +30,13 @@ from argclass.emit import (
     JSONConfigGenerator,
     NonConfigAction,
     TOMLConfigGenerator,
-    coerce_env_value,
     current_value,
     derive_env_var,
     iter_config_fields,
     normalize_value,
     should_emit,
 )
+from argclass.utils import coerce_env_default
 
 
 @pytest.fixture
@@ -743,7 +743,7 @@ class TestGroupReuseAndNesting:
 class TestEdgeCases:
     def test_base_generator_render_not_implemented(self):
         with pytest.raises(NotImplementedError):
-            ConfigGenerator().render({})
+            ConfigGenerator().render(())
 
     def test_ini_skips_none_in_root_and_sections(self):
         """INI cannot natively express None; the renderer drops
@@ -1499,7 +1499,7 @@ class TestFieldsToNestedDict:
 
 
 class TestCoerceEnvValue:
-    """``coerce_env_value`` mirrors argparse's env coercions so the
+    """``coerce_env_default`` mirrors argparse's env coercions so the
     dump-mid-parse path sees parsed-style values instead of raw
     strings. Each branch covered once."""
 
@@ -1508,7 +1508,7 @@ class TestCoerceEnvValue:
             type=int,
             nargs=argclass.Nargs.ONE_OR_MORE,
         )
-        assert coerce_env_value("[1, 2, 3]", arg) == [1, 2, 3]
+        assert coerce_env_default("[1, 2, 3]", arg) == [1, 2, 3]
 
     def test_list_with_bad_literal_returns_raw(self):
         arg = argclass.TypedArgument(
@@ -1516,32 +1516,32 @@ class TestCoerceEnvValue:
             nargs=argclass.Nargs.ONE_OR_MORE,
         )
         # Not parseable as a literal — return the raw string.
-        assert coerce_env_value("not-a-list", arg) == "not-a-list"
+        assert coerce_env_default("not-a-list", arg) == "not-a-list"
 
     def test_bool_store_true_action(self):
         arg = argclass.TypedArgument(action=argclass.Actions.STORE_TRUE)
-        assert coerce_env_value("true", arg) is True
-        assert coerce_env_value("0", arg) is False
+        assert coerce_env_default("true", arg) is True
+        assert coerce_env_default("0", arg) is False
 
     def test_bool_store_false_string_action(self):
         arg = argclass.TypedArgument(action="store_false")
-        assert coerce_env_value("yes", arg) is True
+        assert coerce_env_default("yes", arg) is True
 
     def test_no_type_returns_raw(self):
         """Plain string-valued argument without ``type=`` passes the
         env value through untouched."""
         arg = argclass.TypedArgument()
-        assert coerce_env_value("hello", arg) == "hello"
+        assert coerce_env_default("hello", arg) == "hello"
 
     def test_type_already_correct_returns_raw(self):
         """``type=str`` plus a str env value short-circuits the
         coercion (no redundant ``str("hello")`` call)."""
         arg = argclass.TypedArgument(type=str)
-        assert coerce_env_value("hello", arg) == "hello"
+        assert coerce_env_default("hello", arg) == "hello"
 
     def test_type_conversion_failure_returns_raw(self):
         arg = argclass.TypedArgument(type=int)
-        assert coerce_env_value("not-an-int", arg) == "not-an-int"
+        assert coerce_env_default("not-an-int", arg) == "not-an-int"
 
     def test_type_callable_not_a_class(self):
         """A ``type=`` callable that is not itself a class (e.g.
@@ -1552,7 +1552,7 @@ class TestCoerceEnvValue:
             return value + value
 
         arg = argclass.TypedArgument(type=double)
-        assert coerce_env_value("ab", arg) == "abab"
+        assert coerce_env_default("ab", arg) == "abab"
 
 
 class TestDumpAcceptsPath:

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -280,6 +280,50 @@ class TestSkipNonConfig:
         assert "ver" not in text
         assert "host" in text
 
+    def test_version_and_generate_config_coexist(
+        self,
+        tmp_path: Path,
+        capsys,
+    ):
+        """A parser carrying both ``--version`` and
+        ``--generate-config`` must keep both flags working
+        independently — neither should appear in the dump, and each
+        must still print + exit when invoked."""
+
+        class App(argclass.Parser):
+            host: str = "localhost"
+            port: int = 8080
+            ver = argclass.Argument(
+                "-V",
+                "--version",
+                action=argclass.Actions.VERSION,
+                version="myapp/1.2.3",
+            )
+            generate = argclass.Argument(
+                "--generate-config",
+                action=GenerateConfigAction,
+                generator=INIConfigGenerator,
+            )
+
+        # --version still prints + exits 0; namespace stays clean.
+        with pytest.raises(SystemExit) as exc:
+            App().parse_args(["--version"])
+        assert exc.value.code == 0
+        version_out = capsys.readouterr().out + capsys.readouterr().err
+        assert "1.2.3" in version_out
+
+        # --generate-config still writes the dump; neither version
+        # nor generate-config itself leaks into it.
+        out = tmp_path / "cfg.ini"
+        with pytest.raises(SystemExit) as exc:
+            App().parse_args(["--generate-config", str(out)])
+        assert exc.value.code == 0
+        text = out.read_text()
+        assert "host = localhost" in text
+        assert "port = 8080" in text
+        assert "ver" not in text
+        assert "generate" not in text
+
     def test_custom_non_config_action_skipped(self, tmp_path: Path):
         class MyAction(NonConfigAction):
             def __init__(self, option_strings, dest, **kw):

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -409,6 +409,86 @@ class TestHelpers:
         arg = p.__arguments__["name"]
         assert current_value(p, "name", arg) == "hello"
 
+    def test_current_value_reads_env_var_with_type_conversion(
+        self,
+        make_cli,
+        monkeypatch,
+    ):
+        """Env values arrive as strings; ``current_value`` applies
+        ``argument.type`` so the dump reflects the same value
+        argclass would bind."""
+        CLI = make_cli()
+        p = CLI()
+        monkeypatch.setenv("APP_ENDPOINT_PORT", "9999")
+        arg = p.endpoint.__arguments__["port"]
+        result = current_value(
+            p.endpoint,
+            "port",
+            arg,
+            env_var="APP_ENDPOINT_PORT",
+        )
+        assert result == 9999
+        assert isinstance(result, int)
+
+    def test_current_value_env_type_conversion_failure_returns_raw(
+        self,
+        monkeypatch,
+    ):
+        """If env value cannot be coerced, fall back to the raw
+        string rather than crashing the dump."""
+        monkeypatch.setenv("PORT_BAD", "not-a-number")
+        arg = argclass.TypedArgument(type=int, default=8080)
+        result = current_value(
+            type("Stub", (), {"__dict__": {}})(),
+            "port",
+            arg,
+            env_var="PORT_BAD",
+        )
+        assert result == "not-a-number"
+
+    def test_current_value_reads_namespace_when_provided(self):
+        ns = argparse.Namespace(host="from-cli")
+        arg = argclass.TypedArgument(default="localhost")
+        result = current_value(
+            type("Stub", (), {"__dict__": {}})(),
+            "host",
+            arg,
+            namespace=ns,
+            dest="host",
+        )
+        assert result == "from-cli"
+
+    def test_current_value_namespace_none_falls_through(self):
+        """A namespace dest with value None means argparse hasn't
+        recorded that arg yet (e.g. SUPPRESS default) — fall back
+        to env / default."""
+        ns = argparse.Namespace(host=None)
+        arg = argclass.TypedArgument(default="localhost")
+        result = current_value(
+            type("Stub", (), {"__dict__": {}})(),
+            "host",
+            arg,
+            namespace=ns,
+            dest="host",
+        )
+        assert result == "localhost"
+
+    def test_current_value_namespace_already_correct_type(
+        self,
+        monkeypatch,
+    ):
+        """``isinstance(raw, type_func)`` guard avoids redundant
+        coercion when env value comes back as the right type."""
+        monkeypatch.setenv("FOO", "abc")
+        arg = argclass.TypedArgument(type=str, default="x")
+        result = current_value(
+            type("Stub", (), {"__dict__": {}})(),
+            "foo",
+            arg,
+            env_var="FOO",
+        )
+        assert result == "abc"
+
 
 class TestSourcesInfluenceDump:
     """The dumped config must reflect whichever source argclass

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1554,6 +1554,14 @@ class TestCoerceEnvValue:
         arg = argclass.TypedArgument(type=double)
         assert coerce_env_default("ab", arg) == "abab"
 
+    def test_non_string_input_passes_through(self):
+        """Callers may stash non-string values in kwargs[default]
+        (e.g. a Path or int) before env handling runs. The helper
+        must pass them through untouched."""
+        arg = argclass.TypedArgument(type=int)
+        assert coerce_env_default(42, arg) == 42
+        assert coerce_env_default(None, arg) is None
+
 
 class TestDumpAcceptsPath:
     def test_dump_to_path_object(self, tmp_path: Path):

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1,0 +1,940 @@
+"""Tests for the config-file generator (argclass.emit).
+
+Covers:
+- Round-trip for INI/JSON/TOML across all argument shapes.
+- Nested groups (2- and 3-level) emit correct dotted sections.
+- list/tuple values survive the round-trip.
+- GenerateConfigAction writes to file and to stdout ('-').
+- Help text appears as comments in INI/TOML, dropped in JSON.
+- NonConfigAction-based actions (and --help / --version) are
+  skipped from dumps.
+- Custom ConfigGenerator subclass works (user-defined format).
+"""
+
+import argparse
+import io
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Type
+
+import pytest
+
+import argclass
+from argclass.emit import (
+    ConfigGenerator,
+    EnvConfigGenerator,
+    GenerateConfigAction,
+    HelpMap,
+    INIConfigGenerator,
+    JSONConfigGenerator,
+    NonConfigAction,
+    TOMLConfigGenerator,
+    current_value,
+    derive_env_var,
+    should_emit,
+)
+
+
+@pytest.fixture
+def make_cli() -> Callable[[], Type[argclass.Parser]]:
+    """Factory that builds a fresh parser class per test.
+
+    Group instances live on the class; sharing them across tests
+    leaks parsed state. Each test gets its own class graph.
+    """
+
+    def factory() -> Type[argclass.Parser]:
+        class Credentials(argclass.Group):
+            username: str = "admin"
+            password: str = "secret"
+
+        class Endpoint(argclass.Group):
+            host: str = "localhost"
+            port: int = 8080
+            credentials: Credentials = Credentials()
+
+        class CLI(argclass.Parser):
+            debug: bool = False
+            name: str = argclass.Argument(
+                default="app",
+                help="Application name",
+            )
+            endpoint: Endpoint = Endpoint()
+
+        return CLI
+
+    return factory
+
+
+class TestINIRoundTrip:
+    def test_basic_roundtrip(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(CLI(), str(out))
+
+        loaded = CLI(config_files=[out])
+        loaded.parse_args([])
+        assert loaded.name == "app"
+        assert loaded.endpoint.host == "localhost"
+        assert loaded.endpoint.port == 8080
+        assert loaded.endpoint.credentials.username == "admin"
+        assert loaded.endpoint.credentials.password == "secret"
+
+    def test_after_parse_snapshot(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        p = CLI()
+        p.parse_args(
+            ["--debug", "--name=hello", "--endpoint-host=10.0.0.1"],
+        )
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(p, str(out))
+
+        loaded = CLI(config_files=[out])
+        loaded.parse_args([])
+        assert loaded.debug is True
+        assert loaded.name == "hello"
+        assert loaded.endpoint.host == "10.0.0.1"
+
+    def test_help_text_in_comments(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(CLI(), str(out))
+        text = out.read_text()
+        assert "; Application name" in text
+
+
+class TestJSONRoundTrip:
+    def test_basic_roundtrip(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        out = tmp_path / "cfg.json"
+        JSONConfigGenerator().dump(CLI(), str(out))
+
+        loaded = CLI(
+            config_files=[out],
+            config_parser_class=argclass.JSONDefaultsParser,
+        )
+        loaded.parse_args([])
+        assert loaded.endpoint.host == "localhost"
+        assert loaded.endpoint.credentials.username == "admin"
+
+    def test_no_comments_in_json(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        out = tmp_path / "cfg.json"
+        JSONConfigGenerator().dump(CLI(), str(out))
+        text = out.read_text()
+        assert "Application name" not in text
+        data = json.loads(text)
+        assert data["name"] == "app"
+        assert data["endpoint"]["credentials"]["username"] == "admin"
+
+
+class TestTOMLRoundTrip:
+    def test_basic_roundtrip(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        out = tmp_path / "cfg.toml"
+        TOMLConfigGenerator().dump(CLI(), str(out))
+
+        loaded = CLI(
+            config_files=[out],
+            config_parser_class=argclass.TOMLDefaultsParser,
+        )
+        loaded.parse_args([])
+        assert loaded.endpoint.host == "localhost"
+        assert loaded.endpoint.credentials.username == "admin"
+
+    def test_help_text_in_comments(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        out = tmp_path / "cfg.toml"
+        TOMLConfigGenerator().dump(CLI(), str(out))
+        text = out.read_text()
+        assert "# Application name" in text
+
+    def test_string_escaping(self):
+        gen = TOMLConfigGenerator()
+        assert gen.render_value('hello "world"') == r'"hello \"world\""'
+        assert gen.render_value("a\nb") == r'"a\nb"'
+        assert gen.render_value("c\\d") == r'"c\\d"'
+
+    def test_three_level_nesting(self, tmp_path: Path):
+        class TLS(argclass.Group):
+            cert: str = "/etc/cert"
+
+        class Sec(argclass.Group):
+            tls: TLS = TLS()
+
+        class Conn(argclass.Group):
+            sec: Sec = Sec()
+
+        class App(argclass.Parser):
+            conn: Conn = Conn()
+
+        out = tmp_path / "cfg.toml"
+        TOMLConfigGenerator().dump(App(), str(out))
+        text = out.read_text()
+        assert "[conn.sec.tls]" in text
+
+        loaded = App(
+            config_files=[out],
+            config_parser_class=argclass.TOMLDefaultsParser,
+        )
+        loaded.parse_args([])
+        assert loaded.conn.sec.tls.cert == "/etc/cert"
+
+
+class TestListRoundTrip:
+    def test_list_round_trips(self, tmp_path: Path):
+        class App(argclass.Parser):
+            tags: list[str] = argclass.Argument(
+                nargs=argclass.Nargs.ZERO_OR_MORE,
+                default=["one", "two"],
+            )
+
+        cases: List[Any] = [
+            ("ini", INIConfigGenerator(), argclass.INIDefaultsParser),
+            ("json", JSONConfigGenerator(), argclass.JSONDefaultsParser),
+            ("toml", TOMLConfigGenerator(), argclass.TOMLDefaultsParser),
+        ]
+        for ext, gen, parser_cls in cases:
+            out = tmp_path / f"cfg.{ext}"
+            gen.dump(App(), str(out))
+            loaded = App(
+                config_files=[out],
+                config_parser_class=parser_cls,
+            )
+            loaded.parse_args([])
+            assert loaded.tags == ["one", "two"], f"failed for {ext}"
+
+
+class TestAction:
+    def make_cli(self, generator_cls: type) -> Type[argclass.Parser]:
+        class App(argclass.Parser):
+            host: str = "localhost"
+            gen = argclass.Argument(
+                "--generate-config",
+                action=GenerateConfigAction,
+                generator=generator_cls,
+            )
+
+        return App
+
+    def test_action_writes_file_and_exits(self, tmp_path: Path):
+        App = self.make_cli(INIConfigGenerator)
+        out = tmp_path / "cfg.ini"
+        with pytest.raises(SystemExit) as exc:
+            App().parse_args(["--generate-config", str(out)])
+        assert exc.value.code == 0
+        assert out.exists()
+        assert "host = localhost" in out.read_text()
+
+    def test_action_stdout(self, capsys):
+        App = self.make_cli(INIConfigGenerator)
+        with pytest.raises(SystemExit) as exc:
+            App().parse_args(["--generate-config", "-"])
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert "host = localhost" in captured.out
+
+    def test_action_with_instance_generator(self, tmp_path: Path):
+        """Passing a generator INSTANCE (not class) also works."""
+
+        class App(argclass.Parser):
+            host: str = "localhost"
+            gen = argclass.Argument(
+                "--generate-config",
+                action=GenerateConfigAction,
+                generator=JSONConfigGenerator(),
+            )
+
+        out = tmp_path / "cfg.json"
+        with pytest.raises(SystemExit):
+            App().parse_args(["--generate-config", str(out)])
+        data = json.loads(out.read_text())
+        assert data["host"] == "localhost"
+
+
+class TestSkipNonConfig:
+    def test_generate_config_arg_self_skipped(self, tmp_path: Path):
+        App = TestAction().make_cli(INIConfigGenerator)
+        out = tmp_path / "cfg.ini"
+        with pytest.raises(SystemExit):
+            App().parse_args(["--generate-config", str(out)])
+        text = out.read_text()
+        # The --generate-config flag itself must not appear in its
+        # own output.
+        assert "\ngen " not in text
+        assert "generate" not in text.lower()
+
+    def test_version_action_skipped(self, tmp_path: Path):
+        class App(argclass.Parser):
+            host: str = "localhost"
+            ver = argclass.Argument(
+                "-V",
+                "--version",
+                action=argclass.Actions.VERSION,
+                version="1.0",
+            )
+
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(App(), str(out))
+        text = out.read_text()
+        assert "ver" not in text
+        assert "host" in text
+
+    def test_custom_non_config_action_skipped(self, tmp_path: Path):
+        class MyAction(NonConfigAction):
+            def __init__(self, option_strings, dest, **kw):
+                kw.setdefault("nargs", 0)
+                kw.setdefault("default", None)
+                super().__init__(option_strings, dest, **kw)
+
+            def __call__(self, p, ns, v, opt=None):
+                p.exit(0)
+
+        class App(argclass.Parser):
+            host: str = "localhost"
+            meta = argclass.Argument(action=MyAction)
+
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(App(), str(out))
+        text = out.read_text()
+        assert "meta" not in text
+
+    def test_stateful_custom_action_included(self):
+        """A custom Action that does NOT inherit NonConfigAction is
+        treated as stateful and appears in the dump."""
+
+        class Counter(argparse.Action):
+            def __init__(self, option_strings, dest, **kw):
+                kw.setdefault("nargs", 0)
+                kw.setdefault("default", 0)
+                super().__init__(option_strings, dest, **kw)
+
+            def __call__(self, p, ns, v, opt=None):
+                setattr(ns, self.dest, (getattr(ns, self.dest) or 0) + 1)
+
+        class App(argclass.Parser):
+            host: str = "localhost"
+            counter = argclass.Argument("-v", action=Counter, default=0)
+
+        text = INIConfigGenerator().dump_to_string(App())
+        assert "counter" in text
+
+
+class TestCustomGenerator:
+    def test_user_subclass_renders_custom_format(
+        self,
+        tmp_path: Path,
+        make_cli,
+    ):
+        """A user can subclass ConfigGenerator and override render to
+        produce any text format."""
+
+        class KeyValueGenerator(ConfigGenerator):
+            extension = ".kv"
+
+            def render(
+                self,
+                data: Dict[str, Any],
+                help_map: Optional[HelpMap] = None,
+            ) -> str:
+                lines: List[str] = []
+                self.walk(data, (), lines)
+                return "\n".join(lines) + "\n"
+
+            def walk(
+                self,
+                data: Dict[str, Any],
+                path: tuple,
+                lines: List[str],
+            ) -> None:
+                for key, value in data.items():
+                    if isinstance(value, dict):
+                        self.walk(value, path + (key,), lines)
+                    else:
+                        full_key = ".".join(path + (key,))
+                        lines.append(f"{full_key}={value}")
+
+        CLI = make_cli()
+        out = tmp_path / "cfg.kv"
+        KeyValueGenerator().dump(CLI(), str(out))
+        text = out.read_text()
+        assert "name=app" in text
+        assert "endpoint.host=localhost" in text
+        assert "endpoint.credentials.username=admin" in text
+
+
+class TestHelpers:
+    def test_should_emit_stateful(self):
+        arg = argclass.TypedArgument(action=argclass.Actions.STORE)
+        assert should_emit(arg) is True
+
+    def test_should_emit_skips_version_enum(self):
+        arg = argclass.TypedArgument(action=argclass.Actions.VERSION)
+        assert should_emit(arg) is False
+
+    def test_should_emit_skips_help_enum(self):
+        arg = argclass.TypedArgument(action=argclass.Actions.HELP)
+        assert should_emit(arg) is False
+
+    def test_should_emit_skips_action_class_with_marker(self):
+        arg = argclass.TypedArgument(action=NonConfigAction)
+        assert should_emit(arg) is False
+
+    def test_should_emit_includes_unmarked_action_class(self):
+        class StatefulAction(argparse.Action):
+            def __call__(self, *a, **k):
+                pass
+
+        arg = argclass.TypedArgument(action=StatefulAction)
+        assert should_emit(arg) is True
+
+    def test_should_emit_skips_help_string(self):
+        arg = argclass.TypedArgument(action="help")
+        assert should_emit(arg) is False
+
+    def test_should_emit_skips_version_string(self):
+        arg = argclass.TypedArgument(action="version")
+        assert should_emit(arg) is False
+
+    def test_current_value_falls_back_to_default(self, make_cli):
+        CLI = make_cli()
+        p = CLI()
+        arg = p.__arguments__["name"]
+        assert current_value(p, "name", arg) == "app"
+
+    def test_current_value_reads_parsed(self, make_cli):
+        CLI = make_cli()
+        p = CLI()
+        p.parse_args(["--name=hello"])
+        arg = p.__arguments__["name"]
+        assert current_value(p, "name", arg) == "hello"
+
+
+class TestSourcesInfluenceDump:
+    """The dumped config must reflect whichever source argclass
+    resolved the value from: defaults, config files, env vars, or
+    CLI. The generator reads the parser's CURRENT state, so this is
+    really a property of the value-resolution pipeline — these tests
+    pin it down end-to-end."""
+
+    def test_cli_value_appears_in_dump(self, tmp_path: Path, make_cli):
+        CLI = make_cli()
+        p = CLI()
+        p.parse_args(
+            [
+                "--name=from-cli",
+                "--endpoint-host=cli-host",
+                "--endpoint-credentials-username=cli-user",
+            ],
+        )
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(p, str(out))
+        text = out.read_text()
+        assert "name = from-cli" in text
+        assert "host = cli-host" in text
+        assert "username = cli-user" in text
+
+    def test_env_value_appears_in_dump(
+        self,
+        tmp_path: Path,
+        make_cli,
+        monkeypatch,
+    ):
+        CLI = make_cli()
+        monkeypatch.setenv("APP_NAME", "from-env")
+        monkeypatch.setenv("APP_ENDPOINT_HOST", "env-host")
+        monkeypatch.setenv(
+            "APP_ENDPOINT_CREDENTIALS_USERNAME",
+            "env-user",
+        )
+        p = CLI(auto_env_var_prefix="APP_")
+        p.parse_args([])
+        out = tmp_path / "cfg.toml"
+        TOMLConfigGenerator().dump(p, str(out))
+        text = out.read_text()
+        assert 'name = "from-env"' in text
+        assert 'host = "env-host"' in text
+        assert 'username = "env-user"' in text
+
+    def test_cli_overrides_env_in_dump(
+        self,
+        tmp_path: Path,
+        make_cli,
+        monkeypatch,
+    ):
+        CLI = make_cli()
+        monkeypatch.setenv("APP_NAME", "from-env")
+        p = CLI(auto_env_var_prefix="APP_")
+        p.parse_args(["--name=from-cli"])
+        text = INIConfigGenerator().dump_to_string(p)
+        assert "name = from-cli" in text
+        assert "from-env" not in text
+
+    def test_config_file_value_appears_in_dump(
+        self,
+        tmp_path: Path,
+        make_cli,
+    ):
+        CLI = make_cli()
+        initial = tmp_path / "initial.ini"
+        initial.write_text(
+            "[DEFAULT]\nname = from-config\n[endpoint]\nhost = config-host\n",
+        )
+        p = CLI(config_files=[initial])
+        p.parse_args([])
+        text = INIConfigGenerator().dump_to_string(p)
+        assert "name = from-config" in text
+        assert "host = config-host" in text
+
+    def test_full_roundtrip_with_cli_overrides(
+        self,
+        tmp_path: Path,
+        make_cli,
+    ):
+        """Generate a config from a parser that received CLI args,
+        then load that config into a fresh parser — the CLI-set
+        values must be preserved."""
+        CLI = make_cli()
+        p = CLI()
+        p.parse_args(
+            [
+                "--debug",
+                "--endpoint-port=9999",
+                "--endpoint-credentials-password=hunter2",
+            ],
+        )
+        out = tmp_path / "cfg.json"
+        JSONConfigGenerator().dump(p, str(out))
+
+        fresh_cls = make_cli()
+        loaded = fresh_cls(
+            config_files=[out],
+            config_parser_class=argclass.JSONDefaultsParser,
+        )
+        loaded.parse_args([])
+        assert loaded.debug is True
+        assert loaded.endpoint.port == 9999
+        assert loaded.endpoint.credentials.password == "hunter2"
+
+
+class TestGroupReuseAndNesting:
+    def test_two_distinct_group_instances_dump_independently(
+        self,
+        tmp_path: Path,
+    ):
+        """Two attributes of the same Group class each carry their
+        own state. The dump must reflect both, in their own
+        sections."""
+
+        class Conn(argclass.Group):
+            host: str = "localhost"
+            port: int = 8080
+
+        class App(argclass.Parser):
+            primary: Conn = Conn()
+            secondary: Conn = Conn()
+
+        p = App()
+        p.parse_args(
+            [
+                "--primary-host=primary.example.com",
+                "--secondary-host=secondary.example.com",
+                "--secondary-port=9090",
+            ],
+        )
+        out = tmp_path / "cfg.ini"
+        INIConfigGenerator().dump(p, str(out))
+        text = out.read_text()
+        assert "[primary]" in text
+        assert "[secondary]" in text
+        assert "host = primary.example.com" in text
+        assert "host = secondary.example.com" in text
+        assert "port = 9090" in text
+
+        loaded = App(config_files=[out])
+        loaded.parse_args([])
+        assert loaded.primary.host == "primary.example.com"
+        assert loaded.primary.port == 8080
+        assert loaded.secondary.host == "secondary.example.com"
+        assert loaded.secondary.port == 9090
+
+    def test_nested_groups_three_levels_with_cli_overrides(
+        self,
+        tmp_path: Path,
+    ):
+        """End-to-end: 3-level nesting, CLI overrides at every level,
+        round-trip through INI/JSON/TOML preserves everything."""
+
+        class TLS(argclass.Group):
+            cert: str = "/etc/cert"
+            key: str = "/etc/key"
+
+        class Sec(argclass.Group):
+            tls: TLS = TLS()
+            verify: bool = False
+
+        class Conn(argclass.Group):
+            host: str = "localhost"
+            sec: Sec = Sec()
+
+        class App(argclass.Parser):
+            conn: Conn = Conn()
+
+        cases: List[Any] = [
+            ("ini", INIConfigGenerator, argclass.INIDefaultsParser),
+            ("json", JSONConfigGenerator, argclass.JSONDefaultsParser),
+            ("toml", TOMLConfigGenerator, argclass.TOMLDefaultsParser),
+        ]
+        for ext, gen_cls, parser_cls in cases:
+            p = App()
+            p.parse_args(
+                [
+                    "--conn-host=db.example.com",
+                    "--conn-sec-verify",
+                    "--conn-sec-tls-cert=/new/cert",
+                ],
+            )
+            out = tmp_path / f"cfg.{ext}"
+            gen_cls().dump(p, str(out))
+
+            loaded = App(
+                config_files=[out],
+                config_parser_class=parser_cls,
+            )
+            loaded.parse_args([])
+            assert loaded.conn.host == "db.example.com", ext
+            assert loaded.conn.sec.verify is True, ext
+            assert loaded.conn.sec.tls.cert == "/new/cert", ext
+            assert loaded.conn.sec.tls.key == "/etc/key", ext
+
+
+class TestEdgeCases:
+    def test_base_generator_render_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            ConfigGenerator().render({})
+
+    def test_ini_none_value_renders_empty(self):
+        gen = INIConfigGenerator()
+        assert gen.render_scalar(None) == ""
+
+    def test_ini_bool_value(self):
+        gen = INIConfigGenerator()
+        assert gen.render_scalar(True) == "true"
+        assert gen.render_scalar(False) == "false"
+
+    def test_toml_skips_none_root_and_section(self):
+        class Inner(argclass.Group):
+            ghost: Optional[str] = None
+
+        class App(argclass.Parser):
+            ghost: Optional[str] = None
+            host: str = "localhost"
+            inner: Inner = Inner()
+
+        text = TOMLConfigGenerator().dump_to_string(App())
+        assert "ghost" not in text
+        assert 'host = "localhost"' in text
+
+    def test_json_coerces_non_native_value(self):
+        from datetime import date
+
+        gen = JSONConfigGenerator()
+        result = gen.coerce_value(date(2026, 1, 1))
+        assert result == "2026-01-01"
+
+    def test_action_back_ref_missing_raises(self):
+        """When GenerateConfigAction is attached to a bare argparse
+        ArgumentParser (no argclass back-ref), invocation raises."""
+        ap = argparse.ArgumentParser()
+        ap.add_argument(
+            "--dump",
+            action=GenerateConfigAction,
+            generator=INIConfigGenerator,
+        )
+        with pytest.raises(SystemExit):
+            ap.parse_args(["--dump", "-"])
+
+    def test_help_in_ini_nested_section(self, tmp_path: Path):
+        """INI help comments must also be emitted inside dotted
+        sections, not only [DEFAULT]."""
+
+        class Inner(argclass.Group):
+            value: str = argclass.Argument(
+                default="x",
+                help="Inner help text",
+            )
+
+        class App(argclass.Parser):
+            inner: Inner = Inner()
+
+        text = INIConfigGenerator().dump_to_string(App())
+        assert "; Inner help text" in text
+        assert "[inner]" in text
+
+    def test_help_in_toml_nested_section(self):
+        class Inner(argclass.Group):
+            value: str = argclass.Argument(
+                default="x",
+                help="Inner help text",
+            )
+
+        class App(argclass.Parser):
+            inner: Inner = Inner()
+
+        text = TOMLConfigGenerator().dump_to_string(App())
+        assert "# Inner help text" in text
+        assert "[inner]" in text
+
+    def test_non_config_arg_skipped_in_nested_group(self):
+        """A NonConfigAction-marked argument inside a nested group
+        is skipped from the dump."""
+
+        class MyAction(NonConfigAction):
+            def __init__(self, option_strings, dest, **kw):
+                kw.setdefault("nargs", 0)
+                kw.setdefault("default", None)
+                super().__init__(option_strings, dest, **kw)
+
+            def __call__(self, p, ns, v, opt=None):
+                p.exit(0)
+
+        class Inner(argclass.Group):
+            host: str = "localhost"
+            meta = argclass.Argument(action=MyAction)
+
+        class App(argclass.Parser):
+            inner: Inner = Inner()
+
+        text = INIConfigGenerator().dump_to_string(App())
+        assert "host = localhost" in text
+        assert "meta" not in text
+
+
+class TestEnvConfigGenerator:
+    def test_auto_prefix_emits_all(self, make_cli):
+        CLI = make_cli()
+        p = CLI(auto_env_var_prefix="APP_")
+        text = EnvConfigGenerator().dump_to_string(p)
+        assert "APP_NAME=app" in text
+        assert "APP_DEBUG=false" in text
+        assert "APP_ENDPOINT_HOST=localhost" in text
+        assert "APP_ENDPOINT_PORT=8080" in text
+        assert "APP_ENDPOINT_CREDENTIALS_USERNAME=admin" in text
+        assert "APP_ENDPOINT_CREDENTIALS_PASSWORD=secret" in text
+
+    def test_no_prefix_emits_only_explicit_env_vars(self, make_cli):
+        """Without auto_env_var_prefix, only args carrying an
+        explicit env_var= survive."""
+
+        class App(argclass.Parser):
+            host: str = argclass.Argument(default="localhost")
+            api_key: str = argclass.Argument(
+                default="xxx",
+                env_var="MY_KEY",
+            )
+
+        text = EnvConfigGenerator().dump_to_string(App())
+        assert "MY_KEY=xxx" in text
+        assert "host" not in text.lower()
+
+    def test_help_text_in_comments(self, make_cli):
+        CLI = make_cli()
+        p = CLI(auto_env_var_prefix="APP_")
+        text = EnvConfigGenerator().dump_to_string(p)
+        assert "# Application name" in text
+
+    def test_cli_value_reflects_in_env_dump(self, make_cli):
+        CLI = make_cli()
+        p = CLI(auto_env_var_prefix="APP_")
+        p.parse_args(["--name=from-cli", "--endpoint-host=cli-host"])
+        text = EnvConfigGenerator().dump_to_string(p)
+        assert "APP_NAME=from-cli" in text
+        assert "APP_ENDPOINT_HOST=cli-host" in text
+
+    def test_env_value_reflects_in_env_dump(self, make_cli, monkeypatch):
+        CLI = make_cli()
+        monkeypatch.setenv("APP_NAME", "from-env")
+        p = CLI(auto_env_var_prefix="APP_")
+        p.parse_args([])
+        text = EnvConfigGenerator().dump_to_string(p)
+        assert "APP_NAME=from-env" in text
+
+    def test_list_uses_python_literal(self):
+        class App(argclass.Parser):
+            tags: list[str] = argclass.Argument(
+                nargs=argclass.Nargs.ZERO_OR_MORE,
+                default=["one", "two"],
+            )
+
+        p = App(auto_env_var_prefix="APP_")
+        text = EnvConfigGenerator().dump_to_string(p)
+        # Must be ast.literal_eval-able so env reading round-trips.
+        assert "APP_TAGS=['one', 'two']" in text
+
+    def test_string_with_spaces_is_quoted(self):
+        gen = EnvConfigGenerator()
+        assert gen.render_value("simple") == "simple"
+        assert gen.render_value("has spaces") == '"has spaces"'
+        assert gen.render_value('has "quote"') == r'"has \"quote\""'
+
+    def test_render_raises_when_called_without_env_metadata(self):
+        gen = EnvConfigGenerator()
+        with pytest.raises(NotImplementedError):
+            gen.render({})
+
+    def test_action_wires_env_generator(self, tmp_path: Path):
+        class App(argclass.Parser):
+            host: str = "localhost"
+            gen = argclass.Argument(
+                "--generate-env",
+                action=GenerateConfigAction,
+                generator=EnvConfigGenerator,
+            )
+
+        out = tmp_path / ".env"
+        with pytest.raises(SystemExit):
+            App(auto_env_var_prefix="APP_").parse_args(
+                ["--generate-env", str(out)],
+            )
+        text = out.read_text()
+        assert "APP_HOST=localhost" in text
+
+    def test_env_round_trip(self, make_cli, monkeypatch):
+        """Dump env-style listing, then set those env vars and parse
+        — values come back equal."""
+        CLI = make_cli()
+        p = CLI(auto_env_var_prefix="APP_")
+        p.parse_args(
+            [
+                "--name=hello",
+                "--endpoint-host=prod.example.com",
+                "--endpoint-credentials-username=root",
+            ],
+        )
+        text = EnvConfigGenerator().dump_to_string(p)
+
+        # Parse the dump back into env vars.
+        for line in text.splitlines():
+            if not line or line.startswith("#"):
+                continue
+            key, _, value = line.partition("=")
+            monkeypatch.setenv(key, value)
+
+        loaded = CLI(auto_env_var_prefix="APP_")
+        loaded.parse_args([])
+        assert loaded.name == "hello"
+        assert loaded.endpoint.host == "prod.example.com"
+        assert loaded.endpoint.credentials.username == "root"
+
+
+class TestEnvIntrospection:
+    def test_derive_env_var_explicit_wins(self):
+        arg = argclass.TypedArgument(env_var="EXPLICIT")
+        assert derive_env_var("APP_", "anything", arg) == "EXPLICIT"
+
+    def test_derive_env_var_uses_prefix(self):
+        arg = argclass.TypedArgument()
+        assert derive_env_var("APP_", "host", arg) == "APP_HOST"
+
+    def test_derive_env_var_returns_none_without_prefix(self):
+        arg = argclass.TypedArgument()
+        assert derive_env_var(None, "host", arg) is None
+
+    def test_build_env_map_with_prefix_override(self):
+        """Group(prefix=...) overrides the env-var path segment."""
+
+        class Inner(argclass.Group):
+            value: str = "x"
+
+        class App(argclass.Parser):
+            inner: Inner = Inner(prefix="i")
+
+        p = App(auto_env_var_prefix="APP_")
+        env_map = EnvConfigGenerator().build_env_map(p)
+        assert env_map[("inner", "value")] == "APP_I_VALUE"
+
+    def test_build_env_map_with_empty_prefix(self):
+        class Inner(argclass.Group):
+            value: str = "x"
+
+        class App(argclass.Parser):
+            inner: Inner = Inner(prefix="")
+
+        p = App(auto_env_var_prefix="APP_")
+        env_map = EnvConfigGenerator().build_env_map(p)
+        assert env_map[("inner", "value")] == "APP_VALUE"
+
+    def test_nested_group_skips_non_config_action(self):
+        """NonConfigAction marker on an arg inside a nested group
+        keeps it out of the env_map too."""
+
+        class MetaAction(NonConfigAction):
+            def __init__(self, option_strings, dest, **kw):
+                kw.setdefault("nargs", 0)
+                kw.setdefault("default", None)
+                super().__init__(option_strings, dest, **kw)
+
+            def __call__(self, p, ns, v, opt=None):
+                p.exit(0)
+
+        class Inner(argclass.Group):
+            host: str = "localhost"
+            meta = argclass.Argument(action=MetaAction)
+
+        class App(argclass.Parser):
+            inner: Inner = Inner()
+
+        env_map = EnvConfigGenerator().build_env_map(
+            App(auto_env_var_prefix="APP_"),
+        )
+        assert ("inner", "host") in env_map
+        assert ("inner", "meta") not in env_map
+
+    def test_nested_group_skips_arg_without_resolvable_env(self):
+        """No auto_env_var_prefix AND no explicit env_var on an arg
+        inside a group — that arg is absent from the env_map."""
+
+        class Inner(argclass.Group):
+            quiet: str = "yes"
+            shouted: str = argclass.Argument(
+                default="x",
+                env_var="SHOUTED",
+            )
+
+        class App(argclass.Parser):
+            inner: Inner = Inner()
+
+        env_map = EnvConfigGenerator().build_env_map(App())
+        assert env_map.get(("inner", "shouted")) == "SHOUTED"
+        assert ("inner", "quiet") not in env_map
+
+    def test_none_value_skipped_in_env_dump(self):
+        """A None value (e.g. Optional with no resolved value) is
+        skipped from the env dump even when an env var is configured.
+        """
+
+        class App(argclass.Parser):
+            maybe: Optional[str] = argclass.Argument(
+                default=None,
+                env_var="MAYBE",
+            )
+
+        text = EnvConfigGenerator().dump_to_string(App())
+        assert "MAYBE" not in text
+
+    def test_quote_empty_string(self):
+        assert EnvConfigGenerator().quote_string("") == ""
+
+
+class TestDumpDestinations:
+    def test_dump_to_file_like(self, make_cli):
+        CLI = make_cli()
+        buf = io.StringIO()
+        INIConfigGenerator().dump(CLI(), buf)
+        text = buf.getvalue()
+        assert "host = localhost" in text
+
+    def test_dump_to_string_returns_text(self, make_cli):
+        CLI = make_cli()
+        text = INIConfigGenerator().dump_to_string(CLI())
+        assert "host = localhost" in text

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -693,9 +693,23 @@ class TestEdgeCases:
         with pytest.raises(NotImplementedError):
             ConfigGenerator().render({})
 
-    def test_ini_none_value_renders_empty(self):
-        gen = INIConfigGenerator()
-        assert gen.render_scalar(None) == ""
+    def test_ini_skips_none_in_root_and_sections(self):
+        """INI cannot natively express None; the renderer drops
+        such keys entirely so the reloaded parser falls back to its
+        own default instead of seeing an empty string."""
+
+        class Inner(argclass.Group):
+            ghost: Optional[str] = None
+            present: str = "yes"
+
+        class App(argclass.Parser):
+            ghost: Optional[str] = None
+            present: str = "yes"
+            inner: Inner = Inner()
+
+        text = INIConfigGenerator().dump_to_string(App())
+        assert "ghost" not in text
+        assert "present = yes" in text
 
     def test_ini_bool_value(self):
         gen = INIConfigGenerator()
@@ -1004,6 +1018,207 @@ class TestEnvIntrospection:
 
     def test_quote_empty_string(self):
         assert EnvConfigGenerator().quote_string("") == ""
+
+
+class TestCrossFormatRoundTrip:
+    """End-to-end: take a richly-shaped parser, drive CLI/env values
+    through it, dump to every format, then load each dump back into a
+    FRESH parser of the same shape — every value must come back equal.
+
+    Covers all the features users actually compose in one shot:
+    top-level args of several types, a 2-level + 3-level nested
+    group hierarchy, a `list[T]` field, a `bool` flag, an arg with
+    explicit `env_var=`, and a Secret field.
+    """
+
+    @staticmethod
+    def make_complex_parser() -> Type[argclass.Parser]:
+        class TLS(argclass.Group):
+            cert: str = argclass.Argument(
+                default="/etc/tls/cert",
+                help="TLS certificate path",
+            )
+            key: str = "/etc/tls/key"
+
+        class Security(argclass.Group):
+            tls: TLS = TLS()
+            verify: bool = False
+
+        class Database(argclass.Group):
+            host: str = argclass.Argument(
+                default="db.local",
+                help="Database host",
+            )
+            port: int = 5432
+            security: Security = Security()
+
+        class Logging(argclass.Group):
+            level: str = "info"
+            file: Optional[str] = None
+
+        class App(argclass.Parser):
+            name: str = argclass.Argument(
+                default="myapp",
+                help="App name",
+            )
+            workers: int = 4
+            debug: bool = False
+            tags: list[str] = argclass.Argument(
+                nargs=argclass.Nargs.ZERO_OR_MORE,
+                default=["alpha", "beta"],
+            )
+            token: str = argclass.Argument(
+                default="default-token",
+                env_var="MY_TOKEN",
+                help="API token",
+            )
+            api_key: str = argclass.Secret(default="default-key")
+            db: Database = Database()
+            log: Logging = Logging()
+
+        return App
+
+    @pytest.fixture
+    def populated_parser(
+        self,
+        monkeypatch,
+    ) -> argclass.Parser:
+        """Build a parser, drive CLI args, env vars, and an explicit
+        env_var-bound field through it. The returned instance carries
+        a mixture of values from each source."""
+        App = self.make_complex_parser()
+        # explicit-env_var-bound field
+        monkeypatch.setenv("MY_TOKEN", "secret-from-env")
+        # auto-prefix env vars at every level of the group tree
+        monkeypatch.setenv("APP_WORKERS", "8")
+        monkeypatch.setenv("APP_DB_HOST", "prod.example.com")
+        monkeypatch.setenv("APP_DB_SECURITY_VERIFY", "true")
+
+        parser = App(auto_env_var_prefix="APP_")
+        parser.parse_args(
+            [
+                "--name",
+                "from-cli",
+                "--debug",
+                "--tags",
+                "x",
+                "y",
+                "z",
+                "--api-key",
+                "sk-cli-123",
+                "--db-security-tls-cert",
+                "/cli/cert",
+                "--log-level",
+                "debug",
+            ],
+        )
+        return parser
+
+    @staticmethod
+    def assert_state(parser: argclass.Parser) -> None:
+        """Pin down the exact resolved state after parse_args. Used
+        for both the source parser and every reloaded copy so any
+        format that drops a value gets caught."""
+        assert parser.name == "from-cli"
+        assert parser.workers == 8
+        assert parser.debug is True
+        assert parser.tags == ["x", "y", "z"]
+        assert parser.token == "secret-from-env"
+        # Secret() — value survives round-trip; SecretString masks
+        # its repr but compares equal as a plain string.
+        assert parser.api_key == "sk-cli-123"
+        assert isinstance(parser.api_key, argclass.SecretString)
+        assert parser.db.host == "prod.example.com"
+        assert parser.db.port == 5432
+        assert parser.db.security.verify is True
+        assert parser.db.security.tls.cert == "/cli/cert"
+        assert parser.db.security.tls.key == "/etc/tls/key"
+        assert parser.log.level == "debug"
+        assert parser.log.file is None
+
+    def test_populated_parser_baseline(
+        self,
+        populated_parser: argclass.Parser,
+    ) -> None:
+        """Sanity-check the fixture itself before round-tripping."""
+        self.assert_state(populated_parser)
+
+    @pytest.mark.parametrize(
+        "fmt,generator,parser_cls",
+        [
+            (
+                "ini",
+                INIConfigGenerator,
+                argclass.INIDefaultsParser,
+            ),
+            (
+                "json",
+                JSONConfigGenerator,
+                argclass.JSONDefaultsParser,
+            ),
+            (
+                "toml",
+                TOMLConfigGenerator,
+                argclass.TOMLDefaultsParser,
+            ),
+        ],
+    )
+    def test_file_format_roundtrip(
+        self,
+        tmp_path: Path,
+        populated_parser: argclass.Parser,
+        fmt: str,
+        generator: type,
+        parser_cls: type,
+    ) -> None:
+        out = tmp_path / f"app.{fmt}"
+        generator().dump(populated_parser, str(out))
+
+        # Brand-new parser class graph — no leaked state from the
+        # source parser. Same shape, same defaults.
+        App = self.make_complex_parser()
+        loaded = App(
+            config_files=[out],
+            config_parser_class=parser_cls,
+        )
+        loaded.parse_args([])
+        self.assert_state(loaded)
+
+    def test_env_format_roundtrip(
+        self,
+        populated_parser: argclass.Parser,
+        monkeypatch,
+    ) -> None:
+        """Env round-trip is special: we dump KEY=VALUE lines, then
+        set those env vars and parse a fresh parser with the same
+        auto_env_var_prefix. The reloaded state must match."""
+        text = EnvConfigGenerator().dump_to_string(populated_parser)
+
+        # Wipe the env vars from the source fixture so the env-only
+        # reload exercises ONLY what the dump produced.
+        for key in (
+            "MY_TOKEN",
+            "APP_WORKERS",
+            "APP_DB_HOST",
+            "APP_DB_SECURITY_VERIFY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        # Replay the dumped lines as env vars.
+        for line in text.splitlines():
+            if not line or line.startswith("#"):
+                continue
+            key, _, raw_value = line.partition("=")
+            # Strip surrounding quotes (matches what shell would do).
+            value = raw_value
+            if value.startswith('"') and value.endswith('"'):
+                value = value[1:-1]
+            monkeypatch.setenv(key, value)
+
+        App = self.make_complex_parser()
+        loaded = App(auto_env_var_prefix="APP_")
+        loaded.parse_args([])
+        self.assert_state(loaded)
 
 
 class TestDumpDestinations:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -2092,6 +2092,42 @@ class TestMainModule:
         out = capsys.readouterr().out
         assert "usage" in out.lower()
 
+    def test_generate_config_demo_no_flag_prints_help(self, capsys):
+        """Calling genconfig without --generate-* flag shows the
+        help/source dump and returns 0."""
+        from argclass.__main__ import GenerateConfigDemo
+
+        cmd = GenerateConfigDemo()
+        cmd.parse_args([])
+        assert cmd() == 0
+        out = capsys.readouterr().out
+        assert "Config Generation" in out
+        assert "--generate-ini" in out
+        assert "--generate-toml" in out
+        assert "--generate-json" in out
+        assert "--generate-env" in out
+
+    def test_generate_config_demo_writes_ini(self, capsys):
+        from argclass.__main__ import GenerateConfigDemo
+
+        cmd = GenerateConfigDemo()
+        with pytest.raises(SystemExit):
+            cmd.parse_args(["--generate-ini", "-"])
+        out = capsys.readouterr().out
+        assert "host = localhost" in out
+        assert "[server]" in out
+
+    def test_generate_config_demo_cli_affects_dump(self, capsys):
+        from argclass.__main__ import GenerateConfigDemo
+
+        cmd = GenerateConfigDemo()
+        with pytest.raises(SystemExit):
+            cmd.parse_args(
+                ["--port", "9999", "--generate-toml", "-"],
+            )
+        out = capsys.readouterr().out
+        assert "port = 9999" in out
+
 
 class TestStoreRequiredArgument:
     """Test Store required argument validation."""


### PR DESCRIPTION
## Summary

Adds **config file generation** to argclass — the inverse of the existing `config_files=` reading. A `ConfigGenerator` walks the parser tree (mirroring `Parser._fill_group`), builds a nested dict of the current state, and renders
it. Symmetric with `AbstractDefaultsParser` and its subclasses.

### Built-in generators

| Class                  | Output  | Comments |
|------------------------|---------|----------|
| `INIConfigGenerator`   | INI     | `;` lines from `help=` |
| `JSONConfigGenerator`  | JSON    | dropped (no comments in spec) |
| `TOMLConfigGenerator`  | TOML    | `#` lines from `help=` |
| `EnvConfigGenerator`   | `.env`  | `#` lines from `help=` |

TOML emission is hand-rolled (~50 lines) so the zero-dependency guarantee stays intact. Covers `str`/`int`/`float`/`bool`/`list`/`None`.

### Extension points

- **`ConfigGenerator`** — base class. Subclass and override `render(data, help_map)` to add a new format.
- **`GenerateConfigAction`** — argparse Action that takes a `generator=` passthrough kwarg. Wires `--generate-config FILE` (use `-` for stdout) in user CLIs. Reads CLI args from the argparse namespace and env vars from
  `os.environ` at dump time, so the output reflects the parser's current resolved state even when invoked mid-parse.
- **`NonConfigAction`** — opt-out marker for "fire and exit" actions (`--version`, `--check-updates`, `GenerateConfigAction` itself). Generators consult `__emit_config__` and skip such args from dumps.
  argparse's built-in `--help` / `--version` are recognised by enum value.

### Sources reflected in the dump

Whatever argclass would resolve at the moment of dumping ends up in the output — defaults, `config_files=`, env vars (explicit `env_var=` or `auto_env_var_prefix=`), and CLI args. This makes generation useful for
more than scaffolding: format conversion (load INI, dump TOML), snapshotting a deployed config, or materialising env-based config to a file.

### Demo

```bash
python -m argclass genconfig --generate-ini -
python -m argclass genconfig --generate-toml /tmp/myapp.toml
DEMO_HOST=prod.example.com python -m argclass genconfig --generate-env -
python -m argclass genconfig --port 9999 --tags a b c --generate-toml -
```

### Public API additions

```
argclass.ConfigGenerator
argclass.INIConfigGenerator
argclass.JSONConfigGenerator
argclass.TOMLConfigGenerator
argclass.EnvConfigGenerator
argclass.GenerateConfigAction
argclass.NonConfigAction
```

Plus the introspection helpers in ``argclass.emit``: ``should_emit``, ``current_value``, ``derive_env_var``, ``group_cli_segment``, ``flatten_sections``, and the ``HelpMap`` / ``EnvMap`` type aliases.

### Other changes

- `Parser._make_parser` plumbs a one-line back-reference (`parser.argclass_parser = self`) so `GenerateConfigAction` can recover the argclass parser from the argparse parser during invocation.
- `INIConfigGenerator` skips `None` values (would otherwise reload as empty strings via configparser). Same behaviour now in TOML / `.env`.

### Tests

`tests/test_generate_config.py` — 75 tests covering:

- Per-format round-trip (INI / JSON / TOML / `.env`).
- **Cross-format round-trip** with a richly-shaped parser (3-level nested groups, `list[T]`, `bool`, `Optional`, `Secret()`, explicit `env_var=`, `auto_env_var_prefix=`, CLI args at every level).
- Mid-parse `--generate-config` capturing CLI args + env vars.
- `NonConfigAction` opt-out (and inheritance from it).
- Custom `ConfigGenerator` subclass (user-defined format).
- Edge cases: empty dicts, None values, type-conversion failures, back-reference missing, etc.

100% line/branch coverage on `argclass/emit.py`. Existing tests untouched.

### Documentation

- New dedicated page **`docs/config-generation.md`** with usage, source-precedence semantics, ``EnvConfigGenerator`` walkthrough, ``NonConfigAction`` rules, custom-format subclass example, security
  note, and a **format-migration guide** (one-shot script, ``--generate-config`` mid-flight, bulk pipelines).
- Section added to **`README.md`** with quick examples.
- Snippet in **`docs/llms.txt`** for LLM consumers.
- Cross-references from **`docs/arguments.md`** "Argparse Passthrough Kwargs" section.
- New API entries in **`docs/api.md`** via `autoclass`.
- Demo subcommand **`python -m argclass genconfig`** with four ``--generate-{ini,toml,json,env}`` flags so the feature is self-documenting.

### Limitations (intentional, documented)

- Subparsers are skipped from dumps (they're runtime branches, not config-time state). Dump each subparser  separately if needed.
- Secrets emit their actual values — treat output files as credential-bearing.
- JSON has no comments; help text is dropped only in that format.