### PR TITLE
mask_secrets feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,14 +297,16 @@ The same passthrough lets you ship custom `argparse.Action` subclasses
 that take their own constructor parameters — for example, a
 `--check-updates` flag that queries PyPI:
 
+<!--- name: test_readme_custom_action_pypi_update --->
 ```python
-import argparse, json, urllib.request
+import json, urllib.request
 from importlib.metadata import version as get_version
 
-class CheckPyPIUpdate(argparse.Action):
+import argclass
+
+class CheckPyPIUpdate(argclass.NonConfigAction):
     def __init__(self, option_strings, dest, package_name, **kwargs):
         kwargs.setdefault("nargs", 0)
-        kwargs.setdefault("default", argparse.SUPPRESS)
         self.package_name = package_name
         super().__init__(option_strings, dest, **kwargs)
 
@@ -313,9 +315,11 @@ class CheckPyPIUpdate(argparse.Action):
         with urllib.request.urlopen(url, timeout=5) as r:
             latest = json.load(r)["info"]["version"]
         current = get_version(self.package_name)
-        if current == latest:
-            parser.exit(0, f"{self.package_name} {current} is up to date\n")
-        parser.exit(0, f"Update available: {current} -> {latest}\n")
+        setattr(namespace, self.dest, {
+            "current": current,
+            "latest": latest,
+            "up_to_date": current == latest,
+        })
 
 class CLI(argclass.Parser):
     # --check-updates is auto-derived from the attribute name
@@ -323,6 +327,13 @@ class CLI(argclass.Parser):
         action=CheckPyPIUpdate,
         package_name="argclass",  # passthrough kwarg
     )
+
+cli = CLI()
+cli.parse_args(["--check-updates"])
+assert cli.check_updates["current"] == get_version("argclass")
+assert isinstance(cli.check_updates["latest"], str)
+assert isinstance(cli.check_updates["up_to_date"], bool)
+assert "check_updates" not in argclass.INIConfigGenerator().dump_to_string(cli)
 ```
 
 See [Argparse Passthrough Kwargs](https://docs.argclass.com/arguments.html#argparse-passthrough-kwargs)

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -25,8 +25,13 @@ The attribute name auto-derives the CLI flag, so end users run
 ``myapp --generate-config /etc/myapp.ini`` to write the file, or
 ``myapp --generate-config -`` to print to stdout.
 
-Security note: secret values are emitted as-is. Treat generated files
-like any credential-bearing file.
+Security note: secret values are emitted as-is by default. Pass
+``mask_secrets=True`` to the generator (or to its
+``GenerateConfigAction`` wrapping via an instance) to replace
+``Secret()`` field values with :attr:`SecretString.PLACEHOLDER`,
+so a generated file can be shared as a template without leaking
+credentials. Treat any unmasked generated file like a
+credential-bearing file.
 """
 
 import argparse
@@ -51,6 +56,7 @@ from typing import (
 )
 
 from .parser import get_argclass_parser
+from .secret import SecretString
 from .store import AbstractGroup, AbstractParser, TypedArgument
 from .types import Actions
 from .utils import coerce_env_default
@@ -262,6 +268,7 @@ def iter_config_fields(
     parser: AbstractParser,
     *,
     namespace: Optional[argparse.Namespace] = None,
+    mask_secrets: bool = False,
 ) -> Iterator[ConfigField]:
     """Walk ``parser`` and yield one :class:`ConfigField` per leaf.
 
@@ -273,6 +280,12 @@ def iter_config_fields(
     ``namespace``, when provided, lets fields pick up CLI args that
     argparse has already parsed — used by
     :class:`GenerateConfigAction` mid-parse.
+
+    When ``mask_secrets`` is true, any field whose argument was
+    declared via :func:`argclass.Secret` (or carries
+    ``secret=True``) gets its value replaced with
+    :attr:`SecretString.PLACEHOLDER` so the dump can be shared as a
+    template without leaking credentials.
     """
     auto_prefix = getattr(parser, "_auto_env_var_prefix", None)
     yield from iter_subtree_fields(
@@ -281,6 +294,7 @@ def iter_config_fields(
         cli_path=(),
         auto_prefix=auto_prefix,
         namespace=namespace,
+        mask_secrets=mask_secrets,
     )
 
 
@@ -291,12 +305,16 @@ def iter_subtree_fields(
     cli_path: Tuple[str, ...] = (),
     auto_prefix: Optional[str] = None,
     namespace: Optional[argparse.Namespace] = None,
+    mask_secrets: bool = False,
 ) -> Iterator[ConfigField]:
     """Recursive walker used by :func:`iter_config_fields`.
 
     Power-users can call this directly to walk a sub-tree (for example
     to dump just one nested group). Pass the cumulative ``attr_path``
     and ``cli_path`` you want the yielded fields to carry.
+
+    ``mask_secrets`` mirrors :func:`iter_config_fields` — see its
+    docstring for the semantics.
     """
     node = cast(Any, target)
     cli_prefix = "_".join(cli_path)
@@ -313,13 +331,16 @@ def iter_subtree_fields(
             dest=dest,
             env_var=env_var,
         )
+        value = normalize_value(raw)
+        if mask_secrets and argument.secret and value is not None:
+            value = SecretString.PLACEHOLDER
         yield ConfigField(
             attr_path=attr_path + (name,),
             cli_path=cli_path + (name,),
             dest=dest,
             argument=argument,
             target=target,
-            value=normalize_value(raw),
+            value=value,
             env_var=env_var,
             help=argument.help if argument.help else None,
         )
@@ -332,6 +353,7 @@ def iter_subtree_fields(
             cli_path=child_cli,
             auto_prefix=auto_prefix,
             namespace=namespace,
+            mask_secrets=mask_secrets,
         )
 
 
@@ -369,10 +391,24 @@ class ConfigGenerator:
     Subclasses override :meth:`render`. The base
     :meth:`dump_to_string` and :meth:`dump` methods take care of
     walking the parser and writing to disk / stdout / a file object.
+
+    Parameters
+    ----------
+    mask_secrets:
+        When true, fields declared via :func:`argclass.Secret` (or
+        otherwise carrying ``secret=True``) have their values
+        replaced with :attr:`SecretString.PLACEHOLDER`. Use this to
+        emit a credential-free template config; the resulting file
+        is safe to commit / share. Default is ``False`` — the
+        generator reproduces real credential values exactly so the
+        file round-trips back into a working parser.
     """
 
     #: File extension hint. Subclasses set this.
     extension: str = ""
+
+    def __init__(self, *, mask_secrets: bool = False) -> None:
+        self.mask_secrets = mask_secrets
 
     def render(self, fields: Sequence[ConfigField]) -> str:
         """Render a sequence of :class:`ConfigField` records to text.
@@ -397,7 +433,13 @@ class ConfigGenerator:
         string."""
         # Materialise into a tuple so ``render`` (and any custom
         # subclass) can iterate the field stream multiple times.
-        fields = tuple(iter_config_fields(parser, namespace=namespace))
+        fields = tuple(
+            iter_config_fields(
+                parser,
+                namespace=namespace,
+                mask_secrets=self.mask_secrets,
+            ),
+        )
         return self.render(fields)
 
     def dump(

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -604,11 +604,10 @@ subclasses that take their own constructor parameters. The action receives
 whatever extra kwargs you pass through `Argument(...)` directly in its
 `__init__`. Here is a self-contained example: a `--check-updates` flag that
 queries PyPI for the latest version of a configurable package and prints
-whether an update is available, then exits.
+whether an update is available.
 
 <!--- name: test_args_custom_action_pypi_update --->
 ```python
-import argparse
 import json
 import urllib.request
 from importlib.metadata import PackageNotFoundError
@@ -617,20 +616,20 @@ from importlib.metadata import version as get_installed_version
 import argclass
 
 
-class CheckPyPIUpdateAction(argparse.Action):
-    """Query PyPI for the latest version of ``package_name`` and exit.
+class CheckPyPIUpdateAction(argclass.NonConfigAction):
+    """Query PyPI for the latest version of ``package_name``.
 
     ``package_name`` is supplied by argclass via passthrough kwargs.
-    The action behaves like ``--version`` — flag-style (``nargs=0``),
-    suppressed from the parsed namespace, and exits the process.
+    The action behaves like a flag (``nargs=0``) and stores the result
+    on the parsed namespace. It inherits ``NonConfigAction`` because
+    this runtime check should not appear in generated config files.
     """
 
     def __init__(self, option_strings, dest, package_name, **kwargs):
         kwargs.setdefault("nargs", 0)
-        kwargs.setdefault("default", argparse.SUPPRESS)
         kwargs.setdefault(
             "help",
-            f"Check PyPI for updates to {package_name} and exit",
+            f"Check PyPI for updates to {package_name}",
         )
         self.package_name = package_name
         super().__init__(option_strings, dest, **kwargs)
@@ -646,21 +645,15 @@ class CheckPyPIUpdateAction(argparse.Action):
                 latest = json.load(resp)["info"]["version"]
         except Exception as exc:
             parser.exit(2, f"PyPI check failed: {exc}\n")
-        if current is None:
-            parser.exit(
-                0,
-                f"{self.package_name} {latest} available "
-                "(not installed locally)\n",
-            )
-        if current == latest:
-            parser.exit(
-                0,
-                f"{self.package_name} {current} is up to date\n",
-            )
-        parser.exit(
-            0,
-            f"Update available: {self.package_name} "
-            f"{current} -> {latest}\n",
+
+        setattr(
+            namespace,
+            self.dest,
+            {
+                "current": current,
+                "latest": latest,
+                "up_to_date": current == latest,
+            },
         )
 
 
@@ -672,13 +665,17 @@ class CLI(argclass.Parser):
     )
 
 
-# The class definition wires the action up; running --check-updates
-# would hit PyPI and exit. Here we just verify the parser builds.
 parser = CLI()
-parser.parse_args([])
+parser.parse_args(["--check-updates"])
+assert parser.check_updates["current"] == get_installed_version("argclass")
+assert isinstance(parser.check_updates["latest"], str)
+assert isinstance(parser.check_updates["up_to_date"], bool)
+assert "check_updates" not in argclass.INIConfigGenerator().dump_to_string(
+    parser,
+)
 ```
 
-Run `python myapp.py --check-updates` to see the live PyPI check.
+Run `python myapp.py --check-updates` to perform the live PyPI check.
 
 The pattern generalises to any custom action: declare your own constructor
 parameters, consume them in `__init__` before calling `super().__init__`,
@@ -704,6 +701,7 @@ Otherwise it would end up as a noisy empty entry. Two equivalent opt-outs:
    useful if you already inherit from something else (a third-party
    action, your own base).
 
+<!--- name: test_args_non_config_action_marker --->
 ```python
 import argparse, argclass
 

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -908,6 +908,7 @@ Path(config_path).unlink()
 
 For other formats like YAML, extend `ConfigAction`:
 
+<!--- name: test_config_custom_yaml_action --->
 ```python
 from pathlib import Path
 from typing import Mapping, Any

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -222,6 +222,7 @@ except argclass.EnumValueError as e:
 
 Each exception type includes contextual attributes for debugging:
 
+<!--- name: test_error_exception_attributes_doc --->
 ```python
 import argclass
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -770,6 +770,8 @@ This isolates each test and ensures environment changes don't leak between
 tests.
 
 ```python
+import argclass
+
 def test_with_env(monkeypatch):
     monkeypatch.setenv("APP_HOST", "test-host")
 
@@ -787,6 +789,8 @@ Use pytest's `tmp_path` fixture to create temporary config files. This
 ensures tests are isolated and don't depend on files in your filesystem.
 
 ```python
+import argclass
+
 def test_with_config(tmp_path):
     config_file = tmp_path / "config.ini"
     config_file.write_text("[DEFAULT]\nport = 9000\n")
@@ -805,6 +809,8 @@ Test subcommand dispatch by parsing arguments that include the subcommand
 name, then call the parser to execute the selected subcommand.
 
 ```python
+import argclass
+
 def test_subcommand():
     class Sub(argclass.Parser):
         value: int = 1

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -218,16 +218,17 @@ except SystemExit:
 
 argclass automatically strips `type=` for `VERSION`, `HELP`, `STORE_TRUE`, `STORE_FALSE`, and `COUNT` actions (argparse rejects it). Extra kwargs are frozen as an immutable `MappingProxyType` and merged into the dict passed to `add_argument()`.
 
-The same passthrough enables custom `argparse.Action` subclasses with their own constructor parameters — they read those parameters in `__init__` before delegating to `super().__init__`. Example: a `--check-updates` flag that queries PyPI for the latest version of a configurable package and exits:
+The same passthrough enables custom `argparse.Action` subclasses with their own constructor parameters — they read those parameters in `__init__` before delegating to `super().__init__`. Example: a `--check-updates` flag that queries PyPI for the latest version of a configurable package and stores the result:
 
 ```python
-import argparse, json, urllib.request
+import json, urllib.request
 from importlib.metadata import version as get_version
 
-class CheckPyPIUpdate(argparse.Action):
+import argclass
+
+class CheckPyPIUpdate(argclass.NonConfigAction):
     def __init__(self, option_strings, dest, package_name, **kwargs):
         kwargs.setdefault("nargs", 0)
-        kwargs.setdefault("default", argparse.SUPPRESS)
         self.package_name = package_name
         super().__init__(option_strings, dest, **kwargs)
 
@@ -236,9 +237,11 @@ class CheckPyPIUpdate(argparse.Action):
         with urllib.request.urlopen(url, timeout=5) as r:
             latest = json.load(r)["info"]["version"]
         current = get_version(self.package_name)
-        if current == latest:
-            parser.exit(0, f"{self.package_name} {current} is up to date\n")
-        parser.exit(0, f"Update available: {current} -> {latest}\n")
+        setattr(namespace, self.dest, {
+            "current": current,
+            "latest": latest,
+            "up_to_date": current == latest,
+        })
 
 class CLI(argclass.Parser):
     # --check-updates is auto-derived from the attribute name
@@ -246,4 +249,11 @@ class CLI(argclass.Parser):
         action=CheckPyPIUpdate,
         package_name="argclass",  # passthrough kwarg
     )
+
+cli = CLI()
+cli.parse_args(["--check-updates"])
+assert cli.check_updates["current"] == get_version("argclass")
+assert isinstance(cli.check_updates["latest"], str)
+assert isinstance(cli.check_updates["up_to_date"], bool)
+assert "check_updates" not in argclass.INIConfigGenerator().dump_to_string(cli)
 ```

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1855,3 +1855,126 @@ class TestDumpDestinations:
         CLI = make_cli()
         text = INIConfigGenerator().dump_to_string(CLI())
         assert "host = localhost" in text
+
+
+class TestMaskSecrets:
+    """``mask_secrets=True`` replaces ``Secret()`` field values with
+    :attr:`SecretString.PLACEHOLDER` across every generator while
+    leaving every non-secret field untouched."""
+
+    @staticmethod
+    def make_parser() -> Type[argclass.Parser]:
+        class Inner(argclass.Group):
+            visible: str = "ok"
+            token: str = argclass.Secret(default="inner-secret")
+
+        class App(argclass.Parser):
+            host: str = "localhost"
+            api_key: str = argclass.Secret(default="sk-real-key")
+            password: str = argclass.Secret(default="hunter2")
+            inner: Inner = Inner()
+
+        return App
+
+    def test_default_off_emits_real_values(self):
+        App = self.make_parser()
+        text = INIConfigGenerator().dump_to_string(App())
+        assert "api_key = sk-real-key" in text
+        assert "password = hunter2" in text
+        assert "token = inner-secret" in text
+        assert argclass.SecretString.PLACEHOLDER not in text
+
+    def test_ini_masks_secrets(self):
+        App = self.make_parser()
+        text = INIConfigGenerator(mask_secrets=True).dump_to_string(App())
+        placeholder = argclass.SecretString.PLACEHOLDER
+        assert f"api_key = {placeholder}" in text
+        assert f"password = {placeholder}" in text
+        assert f"token = {placeholder}" in text
+        # Real secret values must not leak.
+        assert "sk-real-key" not in text
+        assert "hunter2" not in text
+        assert "inner-secret" not in text
+        # Non-secret fields untouched.
+        assert "host = localhost" in text
+        assert "visible = ok" in text
+
+    def test_json_masks_secrets(self):
+        App = self.make_parser()
+        text = JSONConfigGenerator(mask_secrets=True).dump_to_string(App())
+        data = json.loads(text)
+        placeholder = argclass.SecretString.PLACEHOLDER
+        assert data["api_key"] == placeholder
+        assert data["password"] == placeholder
+        assert data["inner"]["token"] == placeholder
+        assert data["host"] == "localhost"
+        assert data["inner"]["visible"] == "ok"
+
+    def test_toml_masks_secrets(self):
+        App = self.make_parser()
+        text = TOMLConfigGenerator(mask_secrets=True).dump_to_string(App())
+        placeholder = argclass.SecretString.PLACEHOLDER
+        assert f'api_key = "{placeholder}"' in text
+        assert f'password = "{placeholder}"' in text
+        assert f'token = "{placeholder}"' in text
+        assert "sk-real-key" not in text
+        assert "hunter2" not in text
+
+    def test_env_masks_secrets(self):
+        class App(argclass.Parser):
+            host: str = "localhost"
+            api_key: str = argclass.Secret(default="sk-real-key")
+
+        p = App(auto_env_var_prefix="APP_")
+        text = EnvConfigGenerator(mask_secrets=True).dump_to_string(p)
+        placeholder = argclass.SecretString.PLACEHOLDER
+        assert f"APP_API_KEY={placeholder}" in text
+        assert "APP_HOST=localhost" in text
+        assert "sk-real-key" not in text
+
+    def test_none_secret_still_skipped(self):
+        """A secret whose value is None still drops out of the dump —
+        masking only kicks in when there is something to hide."""
+
+        class App(argclass.Parser):
+            token: Optional[str] = argclass.Secret(default=None)
+            host: str = "localhost"
+
+        text = INIConfigGenerator(mask_secrets=True).dump_to_string(App())
+        assert "token" not in text
+        assert "host = localhost" in text
+
+    def test_iter_config_fields_marks_value(self):
+        """Plumb-through check: the helper that walks the parser
+        carries the mask flag into each yielded :class:`ConfigField`."""
+
+        class App(argclass.Parser):
+            token: str = argclass.Secret(default="real")
+
+        fields = {
+            f.key: f.value for f in iter_config_fields(App(), mask_secrets=True)
+        }
+        assert fields["token"] == argclass.SecretString.PLACEHOLDER
+
+    def test_action_uses_instance_with_mask_secrets(self, tmp_path: Path):
+        """Wiring a configured generator INSTANCE into
+        ``GenerateConfigAction`` propagates the masking choice end to
+        end."""
+
+        class App(argclass.Parser):
+            host: str = "localhost"
+            api_key: str = argclass.Secret(default="sk-real-key")
+            gen = argclass.Argument(
+                "--generate-config",
+                action=GenerateConfigAction,
+                generator=INIConfigGenerator(mask_secrets=True),
+            )
+
+        out = tmp_path / "cfg.ini"
+        with pytest.raises(SystemExit) as exc:
+            App().parse_args(["--generate-config", str(out)])
+        assert exc.value.code == 0
+        text = out.read_text()
+        assert f"api_key = {argclass.SecretString.PLACEHOLDER}" in text
+        assert "sk-real-key" not in text
+        assert "host = localhost" in text


### PR DESCRIPTION
Adds a `mask_secrets` kwarg to the config generators so dumps can be shared as templates without leaking credentials.

- `ConfigGenerator.__init__` accepts `mask_secrets: bool = False`; the flag is propagated through `dump_to_string` → `iter_config_fields` → `iter_subtree_fields`.
- When enabled, every field whose argument carries `secret=True` (i.e. declared via `argclass.Secret(...)`) is emitted with `SecretString.PLACEHOLDER` instead of its real value. `None`-valued secrets are still skipped.
- Works for all four built-in generators (INI / JSON / TOML / `.env`) and for `GenerateConfigAction` when wired with a pre-configured generator instance (`generator=INIConfigGenerator(mask_secrets=True)`).
- Default behavior is unchanged: secrets are emitted as-is so round-tripping a parser through a config file keeps working.
- Module docstring updated to describe the new option and the security tradeoff.

Usage:

```python
INIConfigGenerator(mask_secrets=True).dump(parser, "template.ini")
```