### PR TITLE
Fix Argument typing, modernize to 3.10+, reserve internal attr names

### DIFF
--- a/argclass/__main__.py
+++ b/argclass/__main__.py
@@ -5,7 +5,7 @@ import sys
 import textwrap
 from enum import Enum
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
 import argclass
 
@@ -127,7 +127,7 @@ class BasicDemo(argclass.Parser):
         help="A float argument",
     )
     debug: bool = False
-    nickname: Optional[str] = argclass.Argument(
+    nickname: str | None = argclass.Argument(
         default=None,
         help="Optional string (not required)",
     )
@@ -494,22 +494,22 @@ class GenerateConfigDemo(argclass.Parser):
     # Four flags, one per format. Attribute names auto-derive the
     # CLI flag (generate_ini -> --generate-ini, etc.). The Action
     # exits after writing, so only one can be invoked per run.
-    generate_ini = argclass.Argument(
+    generate_ini: str = argclass.Argument(
         action=argclass.GenerateConfigAction,
         generator=argclass.INIConfigGenerator,
         help="Write INI to FILE (use - for stdout)",
     )
-    generate_toml = argclass.Argument(
+    generate_toml: str = argclass.Argument(
         action=argclass.GenerateConfigAction,
         generator=argclass.TOMLConfigGenerator,
         help="Write TOML to FILE (use - for stdout)",
     )
-    generate_json = argclass.Argument(
+    generate_json: str = argclass.Argument(
         action=argclass.GenerateConfigAction,
         generator=argclass.JSONConfigGenerator,
         help="Write JSON to FILE (use - for stdout)",
     )
-    generate_env = argclass.Argument(
+    generate_env: str = argclass.Argument(
         action=argclass.GenerateConfigAction,
         generator=argclass.EnvConfigGenerator,
         help="Write .env to FILE (use - for stdout)",

--- a/argclass/actions.py
+++ b/argclass/actions.py
@@ -6,7 +6,8 @@ import logging
 from argparse import Action
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import Any
+from collections.abc import Iterable, Mapping, Sequence
 
 try:
     import tomllib
@@ -30,7 +31,7 @@ class ConfigAction(Action):
         self,
         option_strings: Sequence[str],
         dest: str,
-        search_paths: Iterable[Union[str, Path]] = (),
+        search_paths: Iterable[str | Path] = (),
         type: MappingProxyType = MappingProxyType({}),
         help: str = "",
         required: bool = False,
@@ -47,8 +48,8 @@ class ConfigAction(Action):
             default=default,
             required=required,
         )
-        self.search_paths: List[Path] = list(map(Path, search_paths))
-        self._result: Optional[Any] = None
+        self.search_paths: list[Path] = list(map(Path, search_paths))
+        self._result: Any | None = None
 
     def parse(self, *files: Path) -> Any:
         result = {}
@@ -66,8 +67,8 @@ class ConfigAction(Action):
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        values: Optional[Union[str, Any]],
-        option_string: Optional[str] = None,
+        values: str | Any | None,
+        option_string: str | None = None,
     ) -> None:
         if not self._result:
             filenames: Sequence[Path] = list(self.search_paths)

--- a/argclass/defaults.py
+++ b/argclass/defaults.py
@@ -7,7 +7,8 @@ import os
 from abc import ABC, abstractmethod
 from enum import IntEnum
 from pathlib import Path
-from typing import Any, Dict, Iterable, Mapping, Optional, Tuple, Union
+from typing import Any
+from collections.abc import Iterable, Mapping
 
 from .exceptions import ConfigurationError
 from .utils import own_section_items
@@ -57,16 +58,16 @@ class AbstractDefaultsParser(ABC):
 
     def __init__(
         self,
-        paths: Iterable[Union[str, Path]],
+        paths: Iterable[str | Path],
         strict: bool = False,
     ):
         self._paths = list(paths)
         self._strict = strict
-        self._loaded_files: Tuple[Path, ...] = ()
-        self._values: Dict[str, Any] = {}
+        self._loaded_files: tuple[Path, ...] = ()
+        self._values: dict[str, Any] = {}
 
     @property
-    def loaded_files(self) -> Tuple[Path, ...]:
+    def loaded_files(self) -> tuple[Path, ...]:
         """Return tuple of successfully loaded file paths."""
         return self._loaded_files
 
@@ -94,7 +95,7 @@ class AbstractDefaultsParser(ABC):
         self,
         key: str,
         kind: ValueKind = ValueKind.STRING,
-        section: Optional[str] = None,
+        section: str | None = None,
     ) -> Any:
         """Get value with type validation.
 
@@ -189,7 +190,7 @@ class INIDefaultsParser(AbstractDefaultsParser):
         loaded = parser.read(filenames)
         self._loaded_files = tuple(Path(f) for f in loaded)
 
-        result: Dict[str, Any] = dict(
+        result: dict[str, Any] = dict(
             parser.items(parser.default_section, raw=True),
         )
         for section in parser.sections():
@@ -226,7 +227,7 @@ class JSONDefaultsParser(AbstractDefaultsParser):
     """
 
     def parse(self) -> Mapping[str, Any]:
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         loaded_files = []
 
         for path in self._filter_readable_paths():
@@ -264,7 +265,7 @@ class TOMLDefaultsParser(AbstractDefaultsParser):
                 "or 'tomli' package: pip install tomli"
             )
 
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         loaded_files = []
 
         for path in self._filter_readable_paths():

--- a/argclass/emit.py
+++ b/argclass/emit.py
@@ -43,17 +43,10 @@ from enum import Enum
 from pathlib import Path, PurePath
 from typing import (
     Any,
-    Dict,
     IO,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
     cast,
 )
+from collections.abc import Iterable, Iterator, Sequence
 
 from .parser import get_argclass_parser
 from .secret import SecretString
@@ -101,9 +94,9 @@ def current_value(
     name: str,
     argument: TypedArgument,
     *,
-    namespace: Optional[argparse.Namespace] = None,
-    dest: Optional[str] = None,
-    env_var: Optional[str] = None,
+    namespace: argparse.Namespace | None = None,
+    dest: str | None = None,
+    env_var: str | None = None,
 ) -> Any:
     """Read the current value for ``name`` on a Parser/Group instance.
 
@@ -139,10 +132,10 @@ def current_value(
 
 
 def derive_env_var(
-    auto_prefix: Optional[str],
+    auto_prefix: str | None,
     dest: str,
     argument: TypedArgument,
-) -> Optional[str]:
+) -> str | None:
     """Compute the env-var name argclass would read for ``dest``.
 
     Mirrors :meth:`argclass.Parser.get_env_var`. Returns ``None`` when
@@ -244,17 +237,17 @@ class ConfigField:
         Help text declared on the argument, or ``None``.
     """
 
-    attr_path: Tuple[str, ...]
-    cli_path: Tuple[str, ...]
+    attr_path: tuple[str, ...]
+    cli_path: tuple[str, ...]
     dest: str
     argument: TypedArgument
     target: Any
     value: Any
-    env_var: Optional[str]
-    help: Optional[str]
+    env_var: str | None
+    help: str | None
 
     @property
-    def section_path(self) -> Tuple[str, ...]:
+    def section_path(self) -> tuple[str, ...]:
         """Path to the enclosing section, derived from ``attr_path``."""
         return self.attr_path[:-1]
 
@@ -267,7 +260,7 @@ class ConfigField:
 def iter_config_fields(
     parser: AbstractParser,
     *,
-    namespace: Optional[argparse.Namespace] = None,
+    namespace: argparse.Namespace | None = None,
     mask_secrets: bool = False,
 ) -> Iterator[ConfigField]:
     """Walk ``parser`` and yield one :class:`ConfigField` per leaf.
@@ -301,10 +294,10 @@ def iter_config_fields(
 def iter_subtree_fields(
     target: Any,
     *,
-    attr_path: Tuple[str, ...] = (),
-    cli_path: Tuple[str, ...] = (),
-    auto_prefix: Optional[str] = None,
-    namespace: Optional[argparse.Namespace] = None,
+    attr_path: tuple[str, ...] = (),
+    cli_path: tuple[str, ...] = (),
+    auto_prefix: str | None = None,
+    namespace: argparse.Namespace | None = None,
     mask_secrets: bool = False,
 ) -> Iterator[ConfigField]:
     """Recursive walker used by :func:`iter_config_fields`.
@@ -361,7 +354,7 @@ def fields_to_nested_dict(
     fields: Iterable[ConfigField],
     *,
     skip_none: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build a nested dict from a stream of :class:`ConfigField`.
 
     Used by :class:`JSONConfigGenerator`. Each section path becomes a
@@ -369,7 +362,7 @@ def fields_to_nested_dict(
     When ``skip_none`` is true, ``None`` values are omitted entirely
     so reloading falls back to the argument's own default.
     """
-    out: Dict[str, Any] = {}
+    out: dict[str, Any] = {}
     for field in fields:
         if skip_none and field.value is None:
             continue
@@ -427,7 +420,7 @@ class ConfigGenerator:
         self,
         parser: AbstractParser,
         *,
-        namespace: Optional[argparse.Namespace] = None,
+        namespace: argparse.Namespace | None = None,
     ) -> str:
         """Walk ``parser`` and return the rendered config as a
         string."""
@@ -445,9 +438,9 @@ class ConfigGenerator:
     def dump(
         self,
         parser: AbstractParser,
-        dest: Union[str, Path, IO[str]],
+        dest: str | Path | IO[str],
         *,
-        namespace: Optional[argparse.Namespace] = None,
+        namespace: argparse.Namespace | None = None,
     ) -> None:
         """Write the rendered config to ``dest``.
 
@@ -468,13 +461,13 @@ class ConfigGenerator:
 
 def group_fields_by_section(
     fields: Iterable[ConfigField],
-) -> "Dict[Tuple[str, ...], List[ConfigField]]":
+) -> "dict[tuple[str, ...], list[ConfigField]]":
     """Group a stream of fields by ``section_path``.
 
     Preserves the original order both for sections and for fields
     within each section.
     """
-    sections: Dict[Tuple[str, ...], List[ConfigField]] = {}
+    sections: dict[tuple[str, ...], list[ConfigField]] = {}
     for field in fields:
         sections.setdefault(field.section_path, []).append(field)
     return sections
@@ -498,7 +491,7 @@ class INIConfigGenerator(ConfigGenerator):
 
     def render(self, fields: Sequence[ConfigField]) -> str:
         sections = group_fields_by_section(fields)
-        lines: List[str] = []
+        lines: list[str] = []
         root_fields = sections.pop((), [])
         if root_fields:
             lines.append("[DEFAULT]")
@@ -512,8 +505,8 @@ class INIConfigGenerator(ConfigGenerator):
 
     def _emit_fields(
         self,
-        fields: List[ConfigField],
-        lines: List[str],
+        fields: list[ConfigField],
+        lines: list[str],
     ) -> None:
         for field in fields:
             if field.value is None:
@@ -571,7 +564,7 @@ class TOMLConfigGenerator(ConfigGenerator):
 
     def render(self, fields: Sequence[ConfigField]) -> str:
         sections = group_fields_by_section(fields)
-        lines: List[str] = []
+        lines: list[str] = []
         root_fields = sections.pop((), [])
         for field in root_fields:
             if field.value is None:
@@ -630,7 +623,7 @@ class EnvConfigGenerator(ConfigGenerator):
     QUOTE_CHARS = frozenset(' \t\n\r"\\#=')
 
     def render(self, fields: Sequence[ConfigField]) -> str:
-        lines: List[str] = []
+        lines: list[str] = []
         for field in fields:
             if field.env_var is None:
                 continue
@@ -679,9 +672,9 @@ class GenerateConfigAction(NonConfigAction):
 
     def __init__(
         self,
-        option_strings: List[str],
+        option_strings: list[str],
         dest: str,
-        generator: Union[type, ConfigGenerator],
+        generator: type | ConfigGenerator,
         **kwargs: Any,
     ):
         kwargs.setdefault("nargs", 1)
@@ -698,7 +691,7 @@ class GenerateConfigAction(NonConfigAction):
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
         values: Any,
-        option_string: Optional[str] = None,
+        option_string: str | None = None,
     ) -> None:
         # Out-of-band back-reference avoids touching argparse_parser.
         argclass_parser = get_argclass_parser(parser)

--- a/argclass/exceptions.py
+++ b/argclass/exceptions.py
@@ -1,6 +1,6 @@
 """Exception classes for argclass with rich context for debugging."""
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 
 class ArgclassError(Exception):
@@ -31,8 +31,8 @@ class ArgclassError(Exception):
         self,
         message: str,
         *,
-        field_name: Optional[str] = None,
-        hint: Optional[str] = None,
+        field_name: str | None = None,
+        hint: str | None = None,
     ):
         self.message = message
         self.field_name = field_name
@@ -74,10 +74,10 @@ class ArgumentDefinitionError(ArgclassError):
         self,
         message: str,
         *,
-        field_name: Optional[str] = None,
-        aliases: Optional[Tuple[str, ...]] = None,
-        kwargs: Optional[dict] = None,
-        hint: Optional[str] = None,
+        field_name: str | None = None,
+        aliases: tuple[str, ...] | None = None,
+        kwargs: dict | None = None,
+        hint: str | None = None,
     ):
         self.aliases = aliases
         self.kwargs = kwargs
@@ -128,10 +128,10 @@ class TypeConversionError(ArgclassError):
         self,
         message: str,
         *,
-        field_name: Optional[str] = None,
+        field_name: str | None = None,
         value: Any = None,
-        target_type: Optional[type] = None,
-        hint: Optional[str] = None,
+        target_type: type | None = None,
+        hint: str | None = None,
     ):
         self.value = value
         self.target_type = target_type
@@ -181,10 +181,10 @@ class ConfigurationError(ArgclassError):
         self,
         message: str,
         *,
-        field_name: Optional[str] = None,
-        file_path: Optional[str] = None,
-        section: Optional[str] = None,
-        hint: Optional[str] = None,
+        field_name: str | None = None,
+        file_path: str | None = None,
+        section: str | None = None,
+        hint: str | None = None,
     ):
         self.file_path = file_path
         self.section = section
@@ -236,10 +236,10 @@ class EnumValueError(ArgclassError):
         self,
         message: str,
         *,
-        field_name: Optional[str] = None,
-        enum_class: Optional[type] = None,
-        valid_values: Optional[Tuple[str, ...]] = None,
-        hint: Optional[str] = None,
+        field_name: str | None = None,
+        enum_class: type | None = None,
+        valid_values: tuple[str, ...] | None = None,
+        hint: str | None = None,
     ):
         self.enum_class = enum_class
         self.valid_values = valid_values
@@ -281,9 +281,9 @@ class ComplexTypeError(ArgclassError):
         self,
         message: str,
         *,
-        field_name: Optional[str] = None,
+        field_name: str | None = None,
         typespec: Any = None,
-        hint: Optional[str] = None,
+        hint: str | None = None,
     ):
         self.typespec = typespec
         super().__init__(message, field_name=field_name, hint=hint)

--- a/argclass/factory.py
+++ b/argclass/factory.py
@@ -5,17 +5,12 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import (
     Any,
-    Callable,
-    Iterable,
-    List,
     Literal,
-    Optional,
-    Type,
     TypeVar,
-    Union,
     cast,
     overload,
 )
+from collections.abc import Callable, Iterable
 
 from argparse import Action
 
@@ -29,6 +24,7 @@ from .types import (
     Nargs,
     NargsType,
 )
+import builtins
 
 T = TypeVar("T")
 
@@ -36,16 +32,16 @@ T = TypeVar("T")
 # noinspection PyShadowingBuiltins
 def ArgumentSingle(
     *aliases: str,
-    type: Type[T],
-    action: Union[Actions, Type[Action]] = Actions.default(),
-    choices: Optional[Iterable[str]] = None,
-    const: Optional[Any] = None,
-    converter: Optional[Callable[[T], T]] = None,
-    default: Optional[T] = None,
-    env_var: Optional[str] = None,
-    help: Optional[str] = None,
-    metavar: Optional[MetavarType] = None,
-    required: Optional[bool] = None,
+    type: type[T],
+    action: Actions | type[Action] = Actions.default(),
+    choices: Iterable[str] | None = None,
+    const: Any | None = None,
+    converter: Callable[[T], T] | None = None,
+    default: T | None = None,
+    env_var: str | None = None,
+    help: str | None = None,
+    metavar: MetavarType | None = None,
+    required: bool | None = None,
     secret: bool = False,
     **extra_kwargs: Any,
 ) -> T:
@@ -88,20 +84,20 @@ def ArgumentSingle(
 # noinspection PyShadowingBuiltins
 def ArgumentSequence(
     *aliases: str,
-    type: Type[T],
+    type: type[T],
     nargs: NargsType = Nargs.ONE_OR_MORE,
-    action: Union[Actions, Type[Action]] = Actions.default(),
-    choices: Optional[Iterable[str]] = None,
-    const: Optional[Any] = None,
-    converter: Optional[Callable[[List[T]], Any]] = None,
-    default: Optional[List[T]] = None,
-    env_var: Optional[str] = None,
-    help: Optional[str] = None,
-    metavar: Optional[MetavarType] = None,
-    required: Optional[bool] = None,
+    action: Actions | type[Action] = Actions.default(),
+    choices: Iterable[str] | None = None,
+    const: Any | None = None,
+    converter: Callable[[list[T]], Any] | None = None,
+    default: list[T] | None = None,
+    env_var: str | None = None,
+    help: str | None = None,
+    metavar: MetavarType | None = None,
+    required: bool | None = None,
     secret: bool = False,
     **extra_kwargs: Any,
-) -> List[T]:
+) -> list[T]:
     """
     Create a multi-value argument with precise typing.
 
@@ -124,7 +120,7 @@ def ArgumentSequence(
             )
     """
     return cast(
-        List[T],
+        list[T],
         TypedArgument(
             action=action,
             aliases=aliases,
@@ -154,14 +150,14 @@ def Argument(
     type: ConverterType,
     nargs: NargsType,
     converter: Callable[..., R],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
-    default: Optional[Any] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
-    required: Optional[bool] = ...,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
+    default: Any | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
+    required: bool | None = ...,
     secret: bool = ...,
     **extra_kwargs: Any,
 ) -> R: ...
@@ -171,17 +167,17 @@ def Argument(
 @overload
 def Argument(
     *aliases: str,
-    type: Type[T],
+    type: type[T],
     nargs: Literal["?"],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
     converter: None = ...,
-    default: Optional[Any] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
-    required: Optional[bool] = ...,
+    default: Any | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
+    required: bool | None = ...,
     secret: bool = ...,
     **extra_kwargs: Any,
 ) -> T: ...
@@ -193,15 +189,15 @@ def Argument(
     *aliases: str,
     type: Callable[[str], T],
     nargs: Literal["?"],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
     converter: None = ...,
-    default: Optional[Any] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
-    required: Optional[bool] = ...,
+    default: Any | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
+    required: bool | None = ...,
     secret: bool = ...,
     **extra_kwargs: Any,
 ) -> T: ...
@@ -211,20 +207,20 @@ def Argument(
 @overload
 def Argument(
     *aliases: str,
-    type: Type[T],
-    nargs: Union[Literal["*", "+"], int, Nargs],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
+    type: type[T],
+    nargs: Literal["*", "+"] | int | Nargs,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
     converter: None = ...,
-    default: Optional[Any] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
-    required: Optional[bool] = ...,
+    default: Any | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
+    required: bool | None = ...,
     secret: bool = ...,
     **extra_kwargs: Any,
-) -> List[T]: ...
+) -> list[T]: ...
 
 
 # Overload: Callable type + nargs (sequence) → List[T]
@@ -232,36 +228,36 @@ def Argument(
 def Argument(
     *aliases: str,
     type: Callable[[str], T],
-    nargs: Union[Literal["*", "+"], int, Nargs],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
+    nargs: Literal["*", "+"] | int | Nargs,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
     converter: None = ...,
-    default: Optional[Any] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
-    required: Optional[bool] = ...,
+    default: Any | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
+    required: bool | None = ...,
     secret: bool = ...,
     **extra_kwargs: Any,
-) -> List[T]: ...
+) -> list[T]: ...
 
 
 # Overload: Type[T] without nargs (single) → T
 @overload
 def Argument(
     *aliases: str,
-    type: Type[T],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
+    type: type[T],
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
     converter: None = ...,
-    default: Optional[T] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
+    default: T | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
     nargs: None = ...,
-    required: Optional[bool] = ...,
+    required: bool | None = ...,
     secret: bool = ...,
     **extra_kwargs: Any,
 ) -> T: ...
@@ -272,16 +268,16 @@ def Argument(
 def Argument(
     *aliases: str,
     type: Callable[[str], T],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
     converter: None = ...,
-    default: Optional[T] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
+    default: T | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
     nargs: None = ...,
-    required: Optional[bool] = ...,
+    required: bool | None = ...,
     secret: bool = ...,
     **extra_kwargs: Any,
 ) -> T: ...
@@ -292,56 +288,60 @@ def Argument(
 def Argument(
     *aliases: str,
     converter: Callable[..., T],
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
-    default: Optional[Any] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
-    nargs: Optional[NargsType] = ...,
-    required: Optional[bool] = ...,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
+    default: Any | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
+    nargs: NargsType | None = ...,
+    required: bool | None = ...,
     secret: bool = ...,
-    type: Optional[ConverterType] = ...,
+    type: ConverterType | None = ...,
     **extra_kwargs: Any,
 ) -> T: ...
 
 
-# Overload: fallback for dynamic/optional parameters (used by Secret, etc.)
+# Overload: fallback for dynamic/optional parameters (used by Secret, etc.).
+# Returns a bare TypeVar so the result adopts the annotated attribute type
+# (e.g. ``tags: list[str] = Argument(nargs="+")`` infers ``list[str]``)
+# instead of ``Any``, which keeps strict checkers (basedpyright's reportAny)
+# quiet on simple, untyped declarations.
 @overload
 def Argument(
     *aliases: str,
-    action: Union[Actions, Type[Action]] = ...,
-    choices: Optional[Iterable[str]] = ...,
-    const: Optional[Any] = ...,
-    converter: Optional[ConverterType] = ...,
-    default: Optional[Any] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[MetavarType] = ...,
-    nargs: Optional[NargsType] = ...,
-    required: Optional[bool] = ...,
+    action: Actions | type[Action] = ...,
+    choices: Iterable[str] | None = ...,
+    const: Any | None = ...,
+    converter: ConverterType | None = ...,
+    default: Any | None = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: MetavarType | None = ...,
+    nargs: NargsType | None = ...,
+    required: bool | None = ...,
     secret: bool = ...,
-    type: Optional[ConverterType] = ...,
+    type: ConverterType | None = ...,
     **extra_kwargs: Any,
-) -> Any: ...
+) -> T: ...  # type: ignore[type-var]
 
 
 # noinspection PyShadowingBuiltins
 def Argument(
     *aliases: str,
-    action: Union[Actions, Type[Action]] = Actions.default(),
-    choices: Optional[Iterable[str]] = None,
-    const: Optional[Any] = None,
-    converter: Optional[ConverterType] = None,
-    default: Optional[Any] = None,
-    env_var: Optional[str] = None,
-    help: Optional[str] = None,
-    metavar: Optional[MetavarType] = None,
-    nargs: Optional[NargsType] = None,
-    required: Optional[bool] = None,
+    action: Actions | type[Action] = Actions.default(),
+    choices: Iterable[str] | None = None,
+    const: Any | None = None,
+    converter: ConverterType | None = None,
+    default: Any | None = None,
+    env_var: str | None = None,
+    help: str | None = None,
+    metavar: MetavarType | None = None,
+    nargs: NargsType | None = None,
+    required: bool | None = None,
     secret: bool = False,
-    type: Optional[ConverterType] = None,
+    type: ConverterType | None = None,
     **extra_kwargs: Any,
 ) -> Any:
     """
@@ -396,7 +396,7 @@ def Argument(
     if type is not None:
         # Cast type to Type[Any] since we've verified it's not None
         # The actual type could be Type[T] or Callable[[str], T]
-        type_func = cast(Type[Any], type)
+        type_func = cast(builtins.type[Any], type)
         if nargs in ("+", "*") or isinstance(nargs, (int, Nargs)):
             return ArgumentSequence(
                 *aliases,
@@ -405,7 +405,7 @@ def Argument(
                 action=action,
                 choices=choices,
                 const=const,
-                converter=cast(Optional[Callable[[List[Any]], Any]], converter),
+                converter=cast(Callable[[list[Any]], Any] | None, converter),
                 default=default,
                 env_var=env_var,
                 help=help,
@@ -474,15 +474,15 @@ E = TypeVar("E", bound=Enum)
 # Overload: with default value (enum member or string) -> returns EnumType
 @overload
 def EnumArgument(
-    enum_class: Type[E],
+    enum_class: type[E],
     *aliases: str,
-    default: Union[E, str],
-    action: Union[Actions, Type[Action]] = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
-    nargs: Optional[NargsType] = ...,
-    required: Optional[bool] = ...,
+    default: E | str,
+    action: Actions | type[Action] = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: str | None = ...,
+    nargs: NargsType | None = ...,
+    required: bool | None = ...,
     use_value: bool = ...,
     lowercase: bool = ...,
 ) -> E: ...
@@ -491,30 +491,30 @@ def EnumArgument(
 # Overload: without default value -> returns Optional[EnumType]
 @overload
 def EnumArgument(
-    enum_class: Type[E],
+    enum_class: type[E],
     *aliases: str,
-    action: Union[Actions, Type[Action]] = ...,
+    action: Actions | type[Action] = ...,
     default: None = ...,
-    env_var: Optional[str] = ...,
-    help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
-    nargs: Optional[NargsType] = ...,
-    required: Optional[bool] = ...,
+    env_var: str | None = ...,
+    help: str | None = ...,
+    metavar: str | None = ...,
+    nargs: NargsType | None = ...,
+    required: bool | None = ...,
     use_value: bool = ...,
     lowercase: bool = ...,
-) -> Optional[E]: ...
+) -> E | None: ...
 
 
 def EnumArgument(
-    enum_class: Type[E],
+    enum_class: type[E],
     *aliases: str,
-    action: Union[Actions, Type[Action]] = Actions.default(),
-    default: Union[E, str, None] = None,
-    env_var: Optional[str] = None,
-    help: Optional[str] = None,
-    metavar: Optional[str] = None,
-    nargs: Optional[NargsType] = None,
-    required: Optional[bool] = None,
+    action: Actions | type[Action] = Actions.default(),
+    default: E | str | None = None,
+    env_var: str | None = None,
+    help: str | None = None,
+    metavar: str | None = None,
+    nargs: NargsType | None = None,
+    required: bool | None = None,
     use_value: bool = False,
     lowercase: bool = False,
 ) -> Any:
@@ -596,17 +596,17 @@ def EnumArgument(
 # noinspection PyShadowingBuiltins
 def Secret(
     *aliases: str,
-    action: Union[Actions, Type[Action]] = Actions.default(),
-    choices: Optional[Iterable[str]] = None,
-    const: Optional[Any] = None,
-    converter: Optional[ConverterType] = None,
-    default: Optional[Any] = None,
-    env_var: Optional[str] = None,
-    help: Optional[str] = None,
-    metavar: Optional[str] = None,
-    nargs: Optional[NargsType] = None,
-    required: Optional[bool] = None,
-    type: Optional[ConverterType] = None,
+    action: Actions | type[Action] = Actions.default(),
+    choices: Iterable[str] | None = None,
+    const: Any | None = None,
+    converter: ConverterType | None = None,
+    default: Any | None = None,
+    env_var: str | None = None,
+    help: str | None = None,
+    metavar: str | None = None,
+    nargs: NargsType | None = None,
+    required: bool | None = None,
+    type: ConverterType | None = None,
 ) -> Any:
     """
     Create a secret argument that masks sensitive values.
@@ -665,17 +665,17 @@ def Secret(
 # noinspection PyShadowingBuiltins
 def Config(
     *aliases: str,
-    search_paths: Optional[Iterable[Union[Path, str]]] = None,
-    choices: Optional[Iterable[str]] = None,
-    converter: Optional[ConverterType] = None,
-    const: Optional[Any] = None,
-    default: Optional[Any] = None,
-    env_var: Optional[str] = None,
-    help: Optional[str] = None,
-    metavar: Optional[str] = None,
-    nargs: Optional[NargsType] = None,
-    required: Optional[bool] = None,
-    config_class: Type[ConfigArgument] = INIConfig,
+    search_paths: Iterable[Path | str] | None = None,
+    choices: Iterable[str] | None = None,
+    converter: ConverterType | None = None,
+    const: Any | None = None,
+    default: Any | None = None,
+    env_var: str | None = None,
+    help: str | None = None,
+    metavar: str | None = None,
+    nargs: NargsType | None = None,
+    required: bool | None = None,
+    config_class: type[ConfigArgument] = INIConfig,
 ) -> Any:
     """
     Create a configuration file argument.

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -10,19 +10,10 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import (
     Any,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
     NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Type,
     TypeVar,
-    Union,
 )
+from collections.abc import Iterable, Mapping, MutableMapping
 
 from .actions import ConfigAction
 from .defaults import (
@@ -51,11 +42,11 @@ from .utils import (
 
 
 def _make_action_true_argument(
-    kind: Type,
+    kind: type,
     default: Any = None,
 ) -> TypedArgument:
     """Create a TypedArgument for boolean types."""
-    kw: Dict[str, Any] = {"type": kind}
+    kw: dict[str, Any] = {"type": kind}
     if kind is bool:
         if default is False:
             kw["action"] = Actions.STORE_TRUE
@@ -72,9 +63,31 @@ def _make_action_true_argument(
     return TypedArgument(**kw)
 
 
-def _type_is_bool(kind: Type) -> bool:
+def _type_is_bool(kind: type) -> bool:
     """Check if a type is bool or Optional[bool]."""
-    return kind is bool or kind == Optional[bool]
+    return kind is bool or kind == bool | None
+
+
+# Attribute names argclass uses for internal parser state. They are
+# defined on the base classes and must not be shadowed by user-defined
+# arguments, groups, or subparsers.
+RESERVED_ATTRIBUTES = frozenset(
+    {
+        "current_subparsers",
+        "current_subparser",
+        "__parent__",
+    }
+)
+
+
+def reserved_name_error(name: str) -> ArgumentDefinitionError:
+    return ArgumentDefinitionError(
+        f"{name!r} is a reserved argclass attribute and cannot be used "
+        f"as an argument, group, or subparser name.",
+        field_name=name,
+        hint="Rename it; argclass stores internal parser state under "
+        "this name.",
+    )
 
 
 class Meta(ABCMeta):
@@ -83,8 +96,8 @@ class Meta(ABCMeta):
     def __new__(
         mcs,
         name: str,
-        bases: Tuple[Type["Meta"], ...],
-        attrs: Dict[str, Any],
+        bases: tuple[type["Meta"], ...],
+        attrs: dict[str, Any],
     ) -> "Meta":
         # Import here to avoid circular import
         from .factory import EnumArgument
@@ -96,11 +109,19 @@ class Meta(ABCMeta):
 
         # Now get annotations from the created class
         annotations = resolve_annotations(cls)
+        # Annotations defined directly on this class (not inherited).
+        own_annotations = cls.__dict__.get("__annotations__", {})
 
         arguments = {}
         argument_groups = {}
         subparsers = {}
         for key, kind in annotations.items():
+            if key in RESERVED_ATTRIBUTES:
+                # Inherited internal attributes are skipped; declaring one
+                # in this class's own body shadows internal state -> error.
+                if key in own_annotations:
+                    raise reserved_name_error(key)
+                continue
             if key.startswith("_"):
                 continue
 
@@ -111,7 +132,7 @@ class Meta(ABCMeta):
                 argument = None
                 has_explicit_default = False
 
-            annotated_group_cls: Optional[Type[AbstractGroup]] = None
+            annotated_group_cls: type[AbstractGroup] | None = None
             if isinstance(kind, type) and issubclass(kind, AbstractGroup):
                 annotated_group_cls = kind
             else:
@@ -245,7 +266,7 @@ class Meta(ABCMeta):
                         container_type, element_type = ctr_info
                         # Use nargs="+" for required, "*" for optional
                         if is_required:
-                            nargs: Union[str, Nargs] = Nargs.ONE_OR_MORE
+                            nargs: str | Nargs = Nargs.ONE_OR_MORE
                         else:
                             nargs = Nargs.ZERO_OR_MORE
                         # Use converter for non-list containers
@@ -322,6 +343,15 @@ class Meta(ABCMeta):
                 argument_groups[key] = argument
 
         for key, value in attrs.items():
+            if key in RESERVED_ATTRIBUTES:
+                # A reserved name assigned an argument/group/subparser
+                # value shadows internal state; internal properties and
+                # plain defaults are left untouched.
+                if isinstance(
+                    value, (TypedArgument, AbstractGroup, AbstractParser)
+                ):
+                    raise reserved_name_error(key)
+                continue
             if key.startswith("_"):
                 continue
 
@@ -374,11 +404,11 @@ class Destination(NamedTuple):
 
     target: Base
     attribute: str
-    argument: Optional[TypedArgument]
-    action: Optional[Action]
+    argument: TypedArgument | None
+    action: Action | None
 
 
-DestinationsType = MutableMapping[str, Set[Destination]]
+DestinationsType = MutableMapping[str, set[Destination]]
 
 
 class Group(AbstractGroup, Base):
@@ -386,10 +416,10 @@ class Group(AbstractGroup, Base):
 
     def __init__(
         self,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
-        prefix: Optional[str] = None,
-        defaults: Optional[Mapping[str, Any]] = None,
+        title: str | None = None,
+        description: str | None = None,
+        prefix: str | None = None,
+        defaults: Mapping[str, Any] | None = None,
     ):
         self._title = title
         self._description = description
@@ -412,7 +442,7 @@ _argclass_back_refs: "_BackRefMap[ArgumentParser, AbstractParser]" = (
 
 def get_argclass_parser(
     argparse_parser: ArgumentParser,
-) -> Optional["Parser"]:
+) -> "Parser | None":
     """Return the :class:`argclass.Parser` that built
     ``argparse_parser``, or ``None`` if it wasn't built through
     argclass (e.g. a bare ``argparse.ArgumentParser``).
@@ -447,7 +477,7 @@ class Parser(AbstractParser, Base):
         argument: TypedArgument,
         dest: str,
         *aliases: str,
-    ) -> Tuple[str, Action]:
+    ) -> tuple[str, Action]:
         kwargs = argument.get_kwargs()
 
         if not argument.is_positional:
@@ -518,7 +548,7 @@ class Parser(AbstractParser, Base):
     def get_cli_name(name: str) -> str:
         return name.replace("_", "-")
 
-    def get_env_var(self, name: str, argument: TypedArgument) -> Optional[str]:
+    def get_env_var(self, name: str, argument: TypedArgument) -> str | None:
         if argument.env_var is not None:
             return argument.env_var
         if self._auto_env_var_prefix is not None:
@@ -527,14 +557,14 @@ class Parser(AbstractParser, Base):
 
     def __init__(
         self,
-        config_files: Iterable[Union[str, Path]] = (),
-        auto_env_var_prefix: Optional[str] = None,
+        config_files: Iterable[str | Path] = (),
+        auto_env_var_prefix: str | None = None,
         strict_config: bool = False,
-        config_parser_class: Type[AbstractDefaultsParser] = INIDefaultsParser,
+        config_parser_class: type[AbstractDefaultsParser] = INIDefaultsParser,
         **kwargs: Any,
     ):
         super().__init__()
-        self.current_subparsers: Tuple[AbstractParser, ...] = ()
+        self.current_subparsers: tuple[AbstractParser, ...] = ()
         self._config_files = config_files
 
         # Parse config files using the specified parser class
@@ -564,20 +594,20 @@ class Parser(AbstractParser, Base):
 
         self._auto_env_var_prefix = auto_env_var_prefix
         self._parser_kwargs = kwargs
-        self._used_env_vars: Set[str] = set()
-        self._used_secret_env_vars: Set[str] = set()
+        self._used_env_vars: set[str] = set()
+        self._used_secret_env_vars: set[str] = set()
 
     @property
-    def current_subparser(self) -> Optional["AbstractParser"]:
+    def current_subparser(self) -> "AbstractParser | None":
         if not self.current_subparsers:
             return None
         return self.current_subparsers[0]
 
     def _make_parser(
         self,
-        parser: Optional[ArgumentParser] = None,
-        parent_chain: Tuple["AbstractParser", ...] = (),
-    ) -> Tuple[ArgumentParser, DestinationsType]:
+        parser: ArgumentParser | None = None,
+        parent_chain: tuple["AbstractParser", ...] = (),
+    ) -> tuple[ArgumentParser, DestinationsType]:
         if parser is None:
             parser = ArgumentParser(
                 epilog=self._epilog,
@@ -687,10 +717,10 @@ class Parser(AbstractParser, Base):
         destinations: DestinationsType,
         parser: ArgumentParser,
     ) -> None:
-        visited: Set[int] = set()
+        visited: set[int] = set()
         for group_name, group in self.__argument_groups__.items():
             cli_seg = group._prefix if group._prefix is not None else group_name
-            cli_path: Tuple[str, ...] = (cli_seg,) if cli_seg else ()
+            cli_path: tuple[str, ...] = (cli_seg,) if cli_seg else ()
             self._fill_group(
                 group=group,
                 parser=parser,
@@ -704,10 +734,10 @@ class Parser(AbstractParser, Base):
         self,
         group: "Group",
         parser: ArgumentParser,
-        attr_path: Tuple[str, ...],
-        cli_path: Tuple[str, ...],
+        attr_path: tuple[str, ...],
+        cli_path: tuple[str, ...],
         destinations: DestinationsType,
-        visited: Set[int],
+        visited: set[int],
     ) -> None:
         if id(group) in visited:
             raise ArgclassError(
@@ -813,7 +843,7 @@ class Parser(AbstractParser, Base):
         self,
         destinations: DestinationsType,
         parser: ArgumentParser,
-        parent_chain: Tuple["AbstractParser", ...] = (),
+        parent_chain: tuple["AbstractParser", ...] = (),
     ) -> None:
         subparsers = parser.add_subparsers()
         subparser: AbstractParser
@@ -845,14 +875,14 @@ class Parser(AbstractParser, Base):
 
     def parse_args(
         self: ParserType,
-        args: Optional[List[str]] = None,
+        args: list[str] | None = None,
         sanitize_secrets: bool = False,
     ) -> ParserType:
         parser, destinations = self._make_parser()
         parsed_ns = parser.parse_args(args=args)
 
         # Get the chain of selected subparsers from the namespace
-        selected_subparsers: Tuple[AbstractParser, ...] = getattr(
+        selected_subparsers: tuple[AbstractParser, ...] = getattr(
             parsed_ns, "current_subparsers", ()
         )
 

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -34,6 +34,7 @@ from .utils import (
     _unwrap_container_type,
     coerce_env_default,
     deep_getattr,
+    own_annotation_keys,
     parse_bool,
     resolve_annotations,
     unwrap_literal,
@@ -110,7 +111,7 @@ class Meta(ABCMeta):
         # Now get annotations from the created class
         annotations = resolve_annotations(cls)
         # Annotations defined directly on this class (not inherited).
-        own_annotations = cls.__dict__.get("__annotations__", {})
+        own_annotations = own_annotation_keys(cls)
 
         arguments = {}
         argument_groups = {}

--- a/argclass/store.py
+++ b/argclass/store.py
@@ -6,15 +6,8 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import (
     Any,
-    Dict,
-    Iterable,
-    Iterator,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
 )
+from collections.abc import Iterable, Iterator, Mapping
 
 from .actions import (
     ConfigAction,
@@ -32,8 +25,8 @@ class StoreMeta(type):
     def __new__(
         mcs,
         name: str,
-        bases: Tuple[Type["StoreMeta"], ...],
-        attrs: Dict[str, Any],
+        bases: tuple[type["StoreMeta"], ...],
+        attrs: dict[str, Any],
     ) -> "StoreMeta":
         # Create the class first to ensure annotations are available
         # Python 3.14+ (PEP 649) defers annotation evaluation
@@ -58,12 +51,12 @@ class Store(metaclass=StoreMeta):
     """Base class for typed storage with field validation."""
 
     _default_value = object()
-    _fields: Tuple[str, ...]
+    _fields: tuple[str, ...]
 
     def __new__(cls, **kwargs: Any) -> "Store":
         obj = super().__new__(cls)
 
-        type_map: Dict[str, Tuple[Type, Any]] = {}
+        type_map: dict[str, tuple[type, Any]] = {}
         # Use cls.__annotations__ instead of obj.__annotations__ to avoid
         # triggering __getattr__ before _values is initialized (Python 3.14+)
         for key, value in cls.__annotations__.items():
@@ -84,7 +77,7 @@ class Store(metaclass=StoreMeta):
             kwargs[key] = value
         return self.__class__(**kwargs)
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         # noinspection PyProtectedMember
         return {field: getattr(self, field) for field in self._fields}
 
@@ -117,7 +110,7 @@ class ArgumentBase(Store):
                 return False
         return True
 
-    def get_kwargs(self) -> Dict[str, Any]:
+    def get_kwargs(self) -> dict[str, Any]:
         nargs = self.nargs
         if isinstance(nargs, Nargs):
             nargs = nargs.value
@@ -152,19 +145,19 @@ class ArgumentBase(Store):
 class TypedArgument(ArgumentBase):
     """Argument with type information."""
 
-    action: Union[Actions, Type[Action]] = Actions.default()
+    action: Actions | type[Action] = Actions.default()
     aliases: Iterable[str] = frozenset()
-    choices: Optional[Iterable[str]] = None
-    const: Optional[Any] = None
-    converter: Optional[ConverterType] = None
-    default: Optional[Any] = None
+    choices: Iterable[str] | None = None
+    const: Any | None = None
+    converter: ConverterType | None = None
+    default: Any | None = None
     secret: bool = False
-    env_var: Optional[str] = None
+    env_var: str | None = None
     extra_kwargs: Mapping[str, Any] = MappingProxyType({})
-    help: Optional[str] = None
-    metavar: Optional[str] = None
-    nargs: Optional[Union[int, Nargs]] = None
-    required: Optional[bool] = None
+    help: str | None = None
+    metavar: str | None = None
+    nargs: int | Nargs | None = None
+    required: bool | None = None
     type: Any = None
 
     @property
@@ -188,20 +181,20 @@ class TypedArgument(ArgumentBase):
 class ConfigArgument(TypedArgument):
     """Argument for configuration file loading."""
 
-    search_paths: Optional[Iterable[Union[Path, str]]] = None
-    action: Type[ConfigAction]
+    search_paths: Iterable[Path | str] | None = None
+    action: type[ConfigAction]
 
 
 class INIConfig(ConfigArgument):
     """Parse INI file and set results as a value."""
 
-    action: Type[ConfigAction] = INIConfigAction
+    action: type[ConfigAction] = INIConfigAction
 
 
 class JSONConfig(ConfigArgument):
     """Parse JSON file and set results as a value."""
 
-    action: Type[ConfigAction] = JSONConfigAction
+    action: type[ConfigAction] = JSONConfigAction
 
 
 class TOMLConfig(ConfigArgument):
@@ -210,7 +203,7 @@ class TOMLConfig(ConfigArgument):
     Uses stdlib tomllib (Python 3.11+) or tomli package as fallback.
     """
 
-    action: Type[ConfigAction] = TOMLConfigAction
+    action: type[ConfigAction] = TOMLConfigAction
 
 
 class AbstractGroup:
@@ -222,8 +215,8 @@ class AbstractGroup:
 class AbstractParser:
     """Abstract base for parsers."""
 
-    __parent__: Union["AbstractParser", None] = None
-    current_subparsers = ()  # type: Tuple["AbstractParser", ...]
+    __parent__: "AbstractParser | None" = None
+    current_subparsers: tuple["AbstractParser", ...] = ()
 
     def _get_chain(self) -> Iterator["AbstractParser"]:
         yield self

--- a/argclass/store.py
+++ b/argclass/store.py
@@ -1,5 +1,6 @@
 """Store metaclass and argument classes for argclass."""
 
+import builtins
 import collections
 from argparse import Action
 from pathlib import Path
@@ -145,7 +146,9 @@ class ArgumentBase(Store):
 class TypedArgument(ArgumentBase):
     """Argument with type information."""
 
-    action: Actions | type[Action] = Actions.default()
+    # ``builtins.type`` because the ``type`` field below shadows the
+    # builtin in this class's annotation scope (matters on 3.14/PEP 649).
+    action: Actions | builtins.type[Action] = Actions.default()
     aliases: Iterable[str] = frozenset()
     choices: Iterable[str] | None = None
     const: Any | None = None
@@ -182,19 +185,19 @@ class ConfigArgument(TypedArgument):
     """Argument for configuration file loading."""
 
     search_paths: Iterable[Path | str] | None = None
-    action: type[ConfigAction]
+    action: builtins.type[ConfigAction]
 
 
 class INIConfig(ConfigArgument):
     """Parse INI file and set results as a value."""
 
-    action: type[ConfigAction] = INIConfigAction
+    action: builtins.type[ConfigAction] = INIConfigAction
 
 
 class JSONConfig(ConfigArgument):
     """Parse JSON file and set results as a value."""
 
-    action: type[ConfigAction] = JSONConfigAction
+    action: builtins.type[ConfigAction] = JSONConfigAction
 
 
 class TOMLConfig(ConfigArgument):
@@ -203,7 +206,7 @@ class TOMLConfig(ConfigArgument):
     Uses stdlib tomllib (Python 3.11+) or tomli package as fallback.
     """
 
-    action: type[ConfigAction] = TOMLConfigAction
+    action: builtins.type[ConfigAction] = TOMLConfigAction
 
 
 class AbstractGroup:

--- a/argclass/types.py
+++ b/argclass/types.py
@@ -1,14 +1,17 @@
 """Type definitions, enums, and constants for argclass."""
 
 from enum import Enum, IntEnum
-from typing import Any, Callable, Tuple, Union, Literal
+from typing import Any, Union, Literal
+from collections.abc import Callable
 
 # Type aliases
 ConverterType = Callable[[Any], Any]
-NargsType = Union[int, str, "Nargs", Literal["?", "*", "+"]]
-MetavarType = Union[str, Tuple[str, ...]]
+MetavarType = str | tuple[str, ...]
 NoneType = type(None)
-UnionClass = Union[None, int].__class__
+# Introspection helper: the class of a typing.Union alias, used to detect
+# ``Optional[T]`` / ``Union[...]`` annotations (PEP 604 ``X | Y`` is handled
+# separately via ``types.UnionType``). Must stay a typing.Union at runtime.
+UnionClass = Union[None, int].__class__  # noqa: UP007
 
 
 class Actions(str, Enum):
@@ -37,6 +40,9 @@ class Nargs(Enum):
     ONE_OR_MORE = "+"
 
 
+NargsType = int | str | Nargs | Literal["?", "*", "+"]
+
+
 class LogLevelEnum(IntEnum):
     """Standard logging levels."""
 
@@ -51,7 +57,7 @@ class LogLevelEnum(IntEnum):
 
 
 # Container types for automatic nargs handling
-CONTAINER_TYPES: Tuple[type, ...] = (list, set, frozenset, tuple)
+CONTAINER_TYPES: tuple[type, ...] = (list, set, frozenset, tuple)
 
 
 # Boolean string values

--- a/argclass/utils.py
+++ b/argclass/utils.py
@@ -7,17 +7,12 @@ import types
 from pathlib import Path
 from typing import (
     Any,
-    Dict,
     Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
     get_args,
     get_origin,
     get_type_hints,
 )
+from collections.abc import Mapping
 
 from .exceptions import ComplexTypeError
 from .types import (
@@ -31,9 +26,9 @@ from .types import (
 
 
 def read_ini_configs(
-    *paths: Union[str, Path],
+    *paths: str | Path,
     **kwargs: Any,
-) -> Tuple[Mapping[str, Any], Tuple[Path, ...]]:
+) -> tuple[Mapping[str, Any], tuple[Path, ...]]:
     """Read configuration from INI files."""
     kwargs.setdefault("allow_no_value", True)
     kwargs.setdefault("strict", False)
@@ -50,7 +45,7 @@ def read_ini_configs(
 
     config_paths = parser.read(filenames)
 
-    result: Dict[str, Union[str, Dict[str, str]]] = dict(
+    result: dict[str, str | dict[str, str]] = dict(
         parser.items(parser.default_section, raw=True),
     )
 
@@ -63,7 +58,7 @@ def read_ini_configs(
 def own_section_items(
     parser: configparser.ConfigParser,
     section: str,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Return ``section``'s own keys, excluding cascaded ``[DEFAULT]``.
 
     configparser's public API
@@ -77,13 +72,13 @@ def own_section_items(
     one place where we reach into ``parser._sections``. Keeps the
     private-attribute risk to a single well-commented call site.
     """
-    own: Dict[str, str] = dict(
+    own: dict[str, str] = dict(
         parser._sections[section],  # type: ignore[attr-defined]
     )
     return own
 
 
-def deep_getattr(name: str, attrs: Dict[str, Any], *bases: Type) -> Any:
+def deep_getattr(name: str, attrs: dict[str, Any], *bases: type) -> Any:
     """Get attribute from attrs dict or base classes."""
     if name in attrs:
         return attrs[name]
@@ -94,11 +89,11 @@ def deep_getattr(name: str, attrs: Dict[str, Any], *bases: Type) -> Any:
 
 
 def merge_annotations(
-    annotations: Dict[str, Any],
-    *bases: Type,
-) -> Dict[str, Any]:
+    annotations: dict[str, Any],
+    *bases: type,
+) -> dict[str, Any]:
     """Merge annotations from base classes following MRO."""
-    result: Dict[str, Any] = {}
+    result: dict[str, Any] = {}
 
     # Walk the full MRO to collect all inherited annotations
     for base in bases:
@@ -108,7 +103,7 @@ def merge_annotations(
     return result
 
 
-def resolve_annotations(cls: type) -> Dict[str, Any]:
+def resolve_annotations(cls: type) -> dict[str, Any]:
     """Resolve annotations for a class, handling stringified annotations.
 
     Uses typing.get_type_hints() to resolve string annotations
@@ -192,7 +187,7 @@ def _is_union_type(typespec: Any) -> bool:
     return hasattr(types, "UnionType") and isinstance(typespec, types.UnionType)
 
 
-def unwrap_optional(typespec: Any) -> Optional[Any]:
+def unwrap_optional(typespec: Any) -> Any | None:
     """Unwrap Optional[T] to T, return None if not Optional."""
     if not _is_union_type(typespec):
         return None
@@ -220,7 +215,7 @@ def _is_container_type(typespec: Any) -> bool:
     return origin in CONTAINER_TYPES
 
 
-def _unwrap_container_type(typespec: Any) -> Optional[Tuple[type, type]]:
+def _unwrap_container_type(typespec: Any) -> tuple[type, type] | None:
     """
     Unwrap a container type and return (container_origin, element_type).
 
@@ -253,7 +248,7 @@ def _unwrap_container_type(typespec: Any) -> Optional[Tuple[type, type]]:
     return (origin, element_type)
 
 
-def unwrap_literal(typespec: Any) -> Optional[Tuple[type, Tuple[Any, ...]]]:
+def unwrap_literal(typespec: Any) -> tuple[type, tuple[Any, ...]] | None:
     """
     Unwrap Literal[value1, value2, ...] and return (value_type, choices).
 

--- a/argclass/utils.py
+++ b/argclass/utils.py
@@ -119,6 +119,28 @@ def resolve_annotations(cls: type) -> dict[str, Any]:
         )
 
 
+def own_annotation_keys(cls: type) -> frozenset[str]:
+    """Names annotated directly on ``cls`` (not inherited from bases).
+
+    On Python 3.14+ (PEP 649) ``cls.__dict__['__annotations__']`` may be
+    absent because annotations are evaluated lazily, so fall back to
+    ``annotationlib`` in FORWARDREF format — only the keys are needed, so
+    unresolved forward references must not raise.
+    """
+    ann = cls.__dict__.get("__annotations__")
+    if ann is not None:
+        return frozenset(ann)
+    try:
+        import annotationlib  # type: ignore[import-not-found]
+    except ImportError:
+        return frozenset()
+    return frozenset(
+        annotationlib.get_annotations(
+            cls, format=annotationlib.Format.FORWARDREF
+        )
+    )
+
+
 def parse_bool(value: str) -> bool:
     """Parse a string to boolean."""
     return value.lower() in TEXT_TRUE_VALUES

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -280,6 +280,13 @@ implement `__call__` on each subcommand and call `cli()` to dispatch
 automatically to the selected command.
 :::
 
+:::{note}
+`current_subparsers`, `current_subparser`, and `__parent__` are reserved
+for internal parser state — using them as your own argument names raises
+`ArgumentDefinitionError`. See
+[Reserved Attribute Names](subparsers.md#reserved-attribute-names).
+:::
+
 ---
 
 ## Exception-Raising Patterns

--- a/docs/subparsers.md
+++ b/docs/subparsers.md
@@ -190,6 +190,35 @@ assert cli.current_subparsers[0].value == 10
 assert cli() == 10
 ```
 
+## Reserved Attribute Names
+
+argclass stores parser state under a few attribute names. These are
+**reserved** and cannot be used as your own argument, group, or
+subparser names:
+
+| Name | Holds |
+|------|-------|
+| `current_subparsers` | The selected subcommand chain (a tuple) |
+| `current_subparser` | The most specific selected subparser |
+| `__parent__` | Back-reference to the parent parser |
+
+Declaring one of them on a `Parser` or `Group` raises
+`ArgumentDefinitionError` at class-definition time, so the clash is
+caught immediately instead of silently corrupting parser state.
+
+<!--- name: test_subparsers_reserved --->
+```python
+import argclass
+
+try:
+    class CLI(argclass.Parser):
+        current_subparsers: str = "oops"  # reserved name
+except argclass.ArgumentDefinitionError as exc:
+    assert "reserved" in str(exc)
+else:
+    raise AssertionError("expected ArgumentDefinitionError")
+```
+
 ## Shared Arguments with Groups
 
 When multiple subcommands need the same options (like output format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,15 @@ docs = [
 line-length = 80
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "C90"]
+select = ["E", "F", "W", "C90", "UP"]
 ignore = ["C901"]
 
 [tool.ruff.lint.per-file-ignores]
 "docs/conf.py" = ["E501"]
+# Tests intentionally exercise legacy typing forms (typing.Union,
+# Optional, List, ...) to verify backward compatibility alongside the
+# PEP 604/585 forms, so they are exempt from pyupgrade modernization.
+"tests/**" = ["UP"]
 
 [tool.uv]
 default-groups = [
@@ -124,3 +128,8 @@ files = ["argclass", "tests"]
 module = "tests.*"
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
+# Argument()'s fallback overload returns a bare TypeVar so annotated
+# attributes infer their declared type (instead of Any) under strict
+# checkers. Tests assign it to plain locals without annotations, where
+# the TypeVar can't be solved; that's harmless here.
+disable_error_code = ["var-annotated"]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -722,9 +722,9 @@ class TestUnionWithExplicitTypeOrConverter:
         """Same behaviour for typing.Union[A, B] form."""
 
         class Parser(argclass.Parser):
-            dns: Union[
-                ipaddress.IPv4Address, ipaddress.IPv6Address
-            ] = argclass.Argument(type=ipaddress.ip_address)
+            dns: Union[ipaddress.IPv4Address, ipaddress.IPv6Address] = (
+                argclass.Argument(type=ipaddress.ip_address)
+            )
 
         parser = Parser()
         parser.parse_args(["--dns", "10.0.0.1"])
@@ -734,9 +734,9 @@ class TestUnionWithExplicitTypeOrConverter:
         """`Optional[A | B] = Argument(type=...)` should also work."""
 
         class Parser(argclass.Parser):
-            dns: Optional[
-                ipaddress.IPv4Address | ipaddress.IPv6Address
-            ] = argclass.Argument(type=ipaddress.ip_address)
+            dns: Optional[ipaddress.IPv4Address | ipaddress.IPv6Address] = (
+                argclass.Argument(type=ipaddress.ip_address)
+            )
 
         parser = Parser()
         parser.parse_args(["--dns", "8.8.8.8"])

--- a/tests/test_reserved_names.py
+++ b/tests/test_reserved_names.py
@@ -1,0 +1,102 @@
+"""Reserved internal attribute names cannot be used as arguments.
+
+argclass stores parser state under a few attribute names
+(``current_subparsers``, ``current_subparser``, ``__parent__``).
+Declaring an argument/group/subparser with one of these names would
+silently clobber that state, so the metaclass rejects it at class
+definition time.
+"""
+
+import pytest
+
+import argclass
+from argclass.parser import RESERVED_ATTRIBUTES
+
+
+def test_reserved_names_set():
+    assert RESERVED_ATTRIBUTES == frozenset(
+        {"current_subparsers", "current_subparser", "__parent__"}
+    )
+
+
+@pytest.mark.parametrize("name", sorted(RESERVED_ATTRIBUTES))
+def test_reserved_annotation_rejected(name):
+    with pytest.raises(argclass.ArgumentDefinitionError) as exc_info:
+        type(
+            "Bad",
+            (argclass.Parser,),
+            {"__annotations__": {name: str}, name: "x"},
+        )
+    message = str(exc_info.value)
+    assert name in message
+    assert "reserved" in message
+
+
+def test_reserved_argument_value_rejected():
+    with pytest.raises(argclass.ArgumentDefinitionError):
+
+        class Bad(argclass.Parser):
+            current_subparsers = argclass.Argument(  # type: ignore[assignment]
+                type=int
+            )
+
+
+def test_reserved_subparser_value_rejected():
+    class Serve(argclass.Parser):
+        port: int = 8080
+
+    with pytest.raises(argclass.ArgumentDefinitionError):
+
+        class Bad(argclass.Parser):
+            current_subparser = Serve()  # type: ignore[assignment]
+
+
+def test_reserved_group_value_rejected():
+    class Sub(argclass.Group):
+        value: int = 1
+
+    with pytest.raises(argclass.ArgumentDefinitionError):
+
+        class Bad(argclass.Parser):
+            current_subparsers = Sub()  # type: ignore[assignment]
+
+
+def test_reserved_name_rejected_on_group():
+    with pytest.raises(argclass.ArgumentDefinitionError):
+
+        class Bad(argclass.Group):
+            current_subparsers: str = "x"
+
+
+def test_internal_attributes_still_work():
+    """Guard must not break the framework's own use of these names."""
+
+    class Serve(argclass.Parser):
+        port: int = 8080
+
+    class CLI(argclass.Parser):
+        serve = Serve()
+
+    # The reserved names are not exposed as CLI arguments.
+    assert "current_subparsers" not in CLI.__arguments__
+    assert "current_subparser" not in CLI.__arguments__
+
+    parser = CLI()
+    parser.parse_args(["serve", "--port", "9000"])
+
+    assert parser.serve.port == 9000
+    assert isinstance(parser.current_subparser, Serve)
+    assert parser.current_subparsers == (parser.current_subparser,)
+
+
+def test_ordinary_argument_named_similarly_is_allowed():
+    """Only the exact reserved names are blocked, not lookalikes."""
+
+    class CLI(argclass.Parser):
+        subparser_count: int = 3
+        parent: str = "root"
+
+    parser = CLI()
+    parser.parse_args(["--subparser-count", "5", "--parent", "leaf"])
+    assert parser.subparser_count == 5
+    assert parser.parent == "leaf"


### PR DESCRIPTION
## Summary

Three related typing/quality improvements:

1. **`Argument()` no longer infers as `Any`.** The fallback overload now
   returns a bare `TypeVar`, so annotated attributes adopt their declared
   type — `tags: list[str] = Argument(nargs="+")` infers `list[str]` —
   silencing basedpyright's `reportAny` on the common untyped form.

2. **Modernized the library to PEP 604/585 (3.10+):** `Optional[X]` → `X | None`,
   `Union` → `|`, `List`/`Dict`/`Tuple`/`Type` → builtins, `typing.Callable`
   /`Iterable`/`Mapping` → `collections.abc`. Enabled ruff's `UP` rules.
   Tests are exempt (they intentionally exercise legacy typing forms to
   verify backward compatibility).

3. **Reserved internal attribute names.** `current_subparsers`,
   `current_subparser`, and `__parent__` now raise `ArgumentDefinitionError`
   when used as user argument/group/subparser names, instead of silently
   clobbering parser state. This let the load-bearing type-comment on
   `AbstractParser.current_subparsers` become a normal annotation.

## Tests & docs
- New `tests/test_reserved_names.py` (10 tests).
- Documented reserved names in `docs/subparsers.md` + a `pitfalls.md` cross-reference.

## Verification
- `ruff check` clean, `ruff format` clean.
- `mypy` clean (only the pre-existing `tomllib` stdlib-stub baseline).
- 655 tests pass; doc code blocks pass; Sphinx builds without warnings.