### PR TITLE
Fix 13 audit findings; per-instance group/subparser copies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,11 @@ Naming follows the attribute path:
 - JSON/TOML: nested objects/tables
 
 `Group(prefix=...)` overrides only the CLI/env segment for that group;
-config section names always follow the attribute path. Reusing the
-same Group instance in two places raises `ArgclassError` (instantiate
-a separate Group per attribute).
+config section names always follow the attribute path. Class-body
+Group/subparser instances are prototypes: every Parser instance works
+on its own copies, so one Group instance may be bound to several
+attributes (each binding is an independent copy). Only cyclic group
+trees raise `ArgclassError`.
 
 ### Subcommands
 

--- a/argclass/actions.py
+++ b/argclass/actions.py
@@ -70,7 +70,10 @@ class ConfigAction(Action):
         values: str | Any | None,
         option_string: str | None = None,
     ) -> None:
-        if not self._result:
+        # ``None`` is the not-yet-parsed sentinel; an empty dict is a
+        # valid cached result (truthiness would re-parse it and, on a
+        # second invocation, try Path() on the mapping in values).
+        if self._result is None:
             filenames: Sequence[Path] = list(self.search_paths)
             if values:
                 filenames = [Path(values)] + list(filenames)

--- a/argclass/defaults.py
+++ b/argclass/defaults.py
@@ -11,6 +11,7 @@ from typing import Any
 from collections.abc import Iterable, Mapping
 
 from .exceptions import ConfigurationError
+from .types import TEXT_TRUE_VALUES
 from .utils import own_section_items
 
 try:
@@ -166,19 +167,11 @@ class INIDefaultsParser(AbstractDefaultsParser):
     when requested via get_value() with appropriate ValueKind.
     """
 
-    # Values considered as True for boolean conversion
-    BOOL_TRUE_VALUES = frozenset(
-        (
-            "true",
-            "yes",
-            "1",
-            "on",
-            "enable",
-            "enabled",
-            "t",
-            "y",
-        )
-    )
+    # Values considered as True for boolean conversion. Aliased to the
+    # shared constant so this set and ``argclass.parse_bool`` cannot
+    # drift apart; kept as a class attribute so subclasses can still
+    # override it.
+    BOOL_TRUE_VALUES = TEXT_TRUE_VALUES
 
     def parse(self) -> Mapping[str, Any]:
         parser = configparser.ConfigParser(
@@ -186,9 +179,19 @@ class INIDefaultsParser(AbstractDefaultsParser):
             strict=self._strict,
         )
 
-        filenames = self._filter_readable_paths()
-        loaded = parser.read(filenames)
-        self._loaded_files = tuple(Path(f) for f in loaded)
+        loaded: list[Path] = []
+        for path in self._filter_readable_paths():
+            # Mirror the JSON/TOML parsers: in non-strict mode a
+            # malformed file is skipped (best effort), in strict mode
+            # the error propagates.
+            try:
+                read_ok = parser.read([path])
+            except (configparser.Error, OSError):
+                if self._strict:
+                    raise
+                continue
+            loaded.extend(Path(f) for f in read_ok)
+        self._loaded_files = tuple(loaded)
 
         result: dict[str, Any] = dict(
             parser.items(parser.default_section, raw=True),
@@ -275,7 +278,10 @@ class TOMLDefaultsParser(AbstractDefaultsParser):
                     if isinstance(data, dict):
                         result.update(data)
                         loaded_files.append(path)
-            except OSError:
+            # TOMLDecodeError subclasses ValueError in both stdlib
+            # tomllib and the tomli fallback, so a malformed file is
+            # skipped in non-strict mode just like JSON/INI.
+            except (OSError, ValueError):
                 if self._strict:
                     raise
 

--- a/argclass/factory.py
+++ b/argclass/factory.py
@@ -537,9 +537,18 @@ def EnumArgument(
     Returns:
         TypedArgument instance.
     """
+    # Map accepted spellings to members explicitly instead of relying
+    # on ``str.upper()`` round-trips, which break for enums whose
+    # member names are not fully uppercase (``Fast`` -> ``FAST`` ->
+    # KeyError). ``__members__`` includes aliases (e.g. ``WARN`` for
+    # ``WARNING``) so they keep working as inputs; ``choices`` lists
+    # canonical names only.
+    members = enum_class.__members__
     if lowercase:
+        name_map = {n.lower(): m for n, m in members.items()}
         choices = tuple(e.name.lower() for e in enum_class)
     else:
+        name_map = dict(members)
         choices = tuple(e.name for e in enum_class)
 
     if default is not None:
@@ -547,17 +556,17 @@ def EnumArgument(
             pass  # Valid enum member
         elif isinstance(default, str):
             # Validate string is a valid enum member name
-            check_name = default.upper() if lowercase else default
-            valid_names = tuple(e.name for e in enum_class)
-            if check_name not in valid_names:
+            member = members.get(default)
+            if member is None and lowercase:
+                member = name_map.get(default.lower())
+            if member is None:
                 raise EnumValueError(
                     f"default {default!r} is not a valid {enum_class.__name__} "
                     f"member",
                     enum_class=enum_class,
-                    valid_values=valid_names,
+                    valid_values=tuple(e.name for e in enum_class),
                 )
-            # Convert string default to enum member
-            default = enum_class[check_name]
+            default = member
         else:
             raise EnumValueError(
                 f"default must be {enum_class.__name__} member or string, "
@@ -574,9 +583,12 @@ def EnumArgument(
         # Handle existing enum members
         if isinstance(x, enum_class):
             return x.value if use_value else x
-        # Convert string to enum
-        name = x.upper() if lowercase else x
-        member = enum_class[name]
+        # Convert string to enum member via the explicit name map
+        member = name_map.get(x.lower() if lowercase else x)
+        if member is None:
+            # Same failure mode as enum_class[x]; parse_args wraps
+            # converter errors into TypeConversionError.
+            raise KeyError(x)
         return member.value if use_value else member
 
     return TypedArgument(

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -1,5 +1,6 @@
 """Core parser classes for argclass."""
 
+import copy
 import os
 import weakref
 from abc import ABCMeta
@@ -568,6 +569,52 @@ class Group(AbstractGroup, Base):
         self._defaults: Mapping[str, Any] = defaults or {}
 
 
+def _group_reuse_error(path: str) -> ArgclassError:
+    return ArgclassError(
+        "Group instance is referenced more than once in the parser "
+        f"tree (current path: {path}): the group tree must not "
+        "contain cycles.",
+        hint="Remove the self-reference; a group cannot (directly or "
+        "indirectly) contain itself.",
+    )
+
+
+def _clone_group_tree(
+    group: Group,
+    ancestors: set[int],
+    attr_path: tuple[str, ...],
+) -> Group:
+    """Copy ``group`` and its nested groups for one parser instance.
+
+    The group instances registered by the metaclass live on the class
+    body and would otherwise be shared by every instance of the Parser
+    class — a second ``parse_args()`` on another instance would
+    overwrite the first one's values.
+
+    Because every occurrence gets its own copy, assigning one Group
+    instance to several attributes is fine — each binding becomes an
+    independent copy. ``ancestors`` holds the ids along the current
+    path only, so the recursion rejects exactly the unclonable case:
+    a group that (directly or indirectly) contains itself.
+    """
+    if id(group) in ancestors:
+        raise _group_reuse_error(".".join(attr_path))
+    ancestors.add(id(group))
+    try:
+        clone = copy.copy(group)
+        nested: dict[str, Group] = {}
+        for child_name, child in group.__argument_groups__.items():
+            child_clone = _clone_group_tree(
+                child, ancestors, attr_path + (child_name,)
+            )
+            setattr(clone, child_name, child_clone)
+            nested[child_name] = child_clone
+        clone.__argument_groups__ = MappingProxyType(nested)
+        return clone
+    finally:
+        ancestors.discard(id(group))
+
+
 ParserType = TypeVar("ParserType", bound="Parser")
 
 
@@ -737,6 +784,43 @@ class Parser(AbstractParser, Base):
         self._parser_kwargs = kwargs
         self._used_env_vars: set[str] = set()
         self._used_secret_env_vars: set[str] = set()
+        self._materialize_members()
+
+    def _materialize_members(self) -> None:
+        """Give this parser instance its own copies of the declared
+        groups and subparsers.
+
+        The instances collected by the metaclass live on the class
+        body and are shared by every instance of this Parser class;
+        parsing through them would let a second instance overwrite
+        the first one's values. Copying them per instance
+        (recursively, for nested groups and subparser trees) makes
+        every Parser instance own its parsed state, while the
+        class-level prototypes stay pristine.
+        """
+        cls = type(self)
+
+        ancestors: set[int] = set()
+        groups: dict[str, Group] = {}
+        for name, group in cls.__argument_groups__.items():
+            clone = _clone_group_tree(group, ancestors, (name,))
+            setattr(self, name, clone)
+            groups[name] = clone
+        self.__argument_groups__ = MappingProxyType(groups)
+
+        subparsers: dict[str, Any] = {}
+        for name, subparser in cls.__subparsers__.items():
+            sub_clone = copy.copy(subparser)
+            # The shallow copy still references the prototype's own
+            # member clones and env-var bookkeeping; rebuild them.
+            sub_clone._materialize_members()
+            sub_clone._used_env_vars = set(subparser._used_env_vars)
+            sub_clone._used_secret_env_vars = set(
+                subparser._used_secret_env_vars
+            )
+            setattr(self, name, sub_clone)
+            subparsers[name] = sub_clone
+        self.__subparsers__ = MappingProxyType(subparsers)
 
     @property
     def current_subparser(self) -> "AbstractParser | None":
@@ -880,15 +964,11 @@ class Parser(AbstractParser, Base):
         destinations: DestinationsType,
         visited: set[int],
     ) -> None:
+        # Backstop: instance trees are validated at construction time
+        # by ``_clone_group_tree``; this catches cycles wired into the
+        # per-instance mappings after ``__init__``.
         if id(group) in visited:
-            raise ArgclassError(
-                "Group instance is referenced more than once in the parser "
-                f"tree (current path: {'.'.join(attr_path)}). Reusing a "
-                "single Group instance across attributes is not supported "
-                "because state would be shared between locations.",
-                hint="Instantiate a new Group for each attribute, or "
-                "subclass Group to define a dedicated type.",
-            )
+            raise _group_reuse_error(".".join(attr_path))
         visited.add(id(group))
 
         section = ".".join(attr_path)

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -91,6 +91,59 @@ def reserved_name_error(name: str) -> ArgumentDefinitionError:
     )
 
 
+def shadowed_member_error(name: str, member: Any) -> ArgumentDefinitionError:
+    kind = "property" if isinstance(member, property) else "method"
+    return ArgumentDefinitionError(
+        f"Field {name!r} would shadow the {kind} {name!r} defined on a "
+        f"base class or in the class body; argclass would silently "
+        f"replace it and break the parser API.",
+        field_name=name,
+        hint="Rename the field, or pass the callable explicitly via "
+        "Argument(default=...) if a callable default is intended.",
+    )
+
+
+def _shadowed_api_member(
+    key: str,
+    attrs: Mapping[str, Any],
+    bases: tuple[type, ...],
+) -> Any | None:
+    """Return the method/property that a member named ``key`` would
+    clobber, or ``None`` when the name is safe to use.
+
+    Registering ``key`` as an argument replaces the class attribute
+    (the metaclass stores ``...`` placeholders and ``parse_args``
+    assigns parsed values), so a name that currently resolves to a
+    callable or property — ``parse_args``, a user-defined helper —
+    must be rejected instead of silently destroying the API.
+    Inherited argclass members (arguments, groups, subparsers and
+    their ``...`` placeholders) and plain data defaults remain
+    legitimate redefinition targets.
+    """
+    own = attrs.get(key)
+    if (
+        own is not None
+        and not isinstance(own, (TypedArgument, AbstractGroup, AbstractParser))
+        and (
+            callable(own)
+            or isinstance(own, (property, classmethod, staticmethod))
+        )
+    ):
+        return own
+    for base in bases:
+        if not hasattr(base, key):
+            continue
+        value = getattr(base, key)
+        if value is None or value is Ellipsis:
+            return None
+        if isinstance(value, (TypedArgument, AbstractGroup, AbstractParser)):
+            return None
+        if callable(value) or isinstance(value, property):
+            return value
+        return None
+    return None
+
+
 class Meta(ABCMeta):
     """Metaclass for Parser and Group classes."""
 
@@ -113,9 +166,31 @@ class Meta(ABCMeta):
         # Annotations defined directly on this class (not inherited).
         own_annotations = own_annotation_keys(cls)
 
-        arguments = {}
-        argument_groups = {}
-        subparsers = {}
+        # Seed the registries with inherited members so unannotated
+        # arguments, groups, and subparsers declared on a base class
+        # survive subclassing (annotated fields are re-collected below
+        # from the merged annotations either way).
+        arguments: dict[str, Any] = {}
+        argument_groups: dict[str, Any] = {}
+        subparsers: dict[str, Any] = {}
+        for base in reversed(bases):
+            arguments.update(getattr(base, "__arguments__", {}))
+            argument_groups.update(getattr(base, "__argument_groups__", {}))
+            subparsers.update(getattr(base, "__subparsers__", {}))
+
+        # Keys (re)defined by this class itself, as opposed to seeded.
+        own_keys: set[str] = set()
+
+        def classify(key: str, value: Any, into: dict[str, Any]) -> None:
+            # A redefinition may change category (e.g. an inherited
+            # argument overridden by a group); drop the stale entry
+            # from the other registries.
+            for registry in (arguments, argument_groups, subparsers):
+                if registry is not into:
+                    registry.pop(key, None)
+            into[key] = value
+            own_keys.add(key)
+
         for key, kind in annotations.items():
             if key in RESERVED_ATTRIBUTES:
                 # Inherited internal attributes are skipped; declaring one
@@ -126,12 +201,62 @@ class Meta(ABCMeta):
             if key.startswith("_"):
                 continue
 
+            # A purely inherited member (not re-annotated and not
+            # re-assigned here) is already fully processed in the
+            # seeded registries. Rebuilding it from the annotation
+            # would lose state the base class attrs no longer carry:
+            # plain defaults become ``...`` placeholders on the class,
+            # so a re-build would turn ``name: str = "x"`` into a
+            # required argument in every subclass.
+            if (
+                key not in own_annotations
+                and key not in attrs
+                and (
+                    key in arguments
+                    or key in argument_groups
+                    or key in subparsers
+                )
+            ):
+                continue
+
             try:
                 argument = deep_getattr(key, attrs, *bases)
                 has_explicit_default = True
             except KeyError:
                 argument = None
                 has_explicit_default = False
+
+            shadowed = _shadowed_api_member(key, attrs, bases)
+            if shadowed is not None:
+                raise shadowed_member_error(key, shadowed)
+
+            # Subparsers are defined by instances, not annotations: a
+            # bare ``serve: Serve`` (or ``Serve | None``) would
+            # otherwise fall through and silently become a required
+            # CLI argument with ``type=Serve``.
+            parser_kind: type | None = None
+            if isinstance(kind, type) and issubclass(kind, AbstractParser):
+                parser_kind = kind
+            else:
+                try:
+                    _inner = unwrap_optional(kind)
+                except ComplexTypeError:
+                    _inner = None
+                if isinstance(_inner, type) and issubclass(
+                    _inner, AbstractParser
+                ):
+                    parser_kind = _inner
+            if parser_kind is not None and not isinstance(
+                argument, AbstractParser
+            ):
+                raise ArgumentDefinitionError(
+                    f"Subparser field '{key}' is annotated with parser "
+                    f"class {parser_kind.__name__} but no instance is "
+                    f"assigned; an annotation alone cannot define a "
+                    f"subcommand.",
+                    field_name=key,
+                    hint=f"Use '{key} = {parser_kind.__name__}()'.",
+                )
 
             annotated_group_cls: type[AbstractGroup] | None = None
             if isinstance(kind, type) and issubclass(kind, AbstractGroup):
@@ -292,12 +417,15 @@ class Meta(ABCMeta):
 
             if isinstance(argument, TypedArgument):
                 if argument.type is None and argument.converter is None:
+                    # The same Argument() instance may be shared by
+                    # several fields or classes; mutate a private copy
+                    # so this field's inferred type/nargs/choices do
+                    # not leak into the other bindings.
+                    argument = argument.copy()
                     # First try to unwrap optional
                     optional_inner = unwrap_optional(kind)
                     if optional_inner is not None:
                         kind = optional_inner
-                        if argument.default is None:
-                            argument.default = None
 
                     # Handle bool type: set STORE_TRUE/STORE_FALSE action
                     if kind is bool and argument.action == Actions.default():
@@ -339,9 +467,14 @@ class Meta(ABCMeta):
                             argument.converter = container_type
                     else:
                         argument.type = kind
-                arguments[key] = argument
+                classify(key, argument, arguments)
             elif isinstance(argument, AbstractGroup):
-                argument_groups[key] = argument
+                classify(key, argument, argument_groups)
+            else:
+                # Only Parser instances can reach this point: the
+                # block above converts every non-argclass value into
+                # a TypedArgument.
+                classify(key, argument, subparsers)
 
         for key, value in attrs.items():
             if key in RESERVED_ATTRIBUTES:
@@ -357,15 +490,22 @@ class Meta(ABCMeta):
                 continue
 
             # Skip if already processed from annotations
-            if key in arguments or key in argument_groups or key in subparsers:
+            if key in own_keys:
                 continue
 
+            if isinstance(
+                value, (TypedArgument, AbstractGroup, AbstractParser)
+            ):
+                shadowed = _shadowed_api_member(key, attrs, bases)
+                if shadowed is not None:
+                    raise shadowed_member_error(key, shadowed)
+
             if isinstance(value, TypedArgument):
-                arguments[key] = value
+                classify(key, value, arguments)
             elif isinstance(value, AbstractGroup):
-                argument_groups[key] = value
+                classify(key, value, argument_groups)
             elif isinstance(value, AbstractParser):
-                subparsers[key] = value
+                classify(key, value, subparsers)
 
         setattr(cls, "__arguments__", MappingProxyType(arguments))
         setattr(cls, "__argument_groups__", MappingProxyType(argument_groups))
@@ -909,8 +1049,16 @@ class Parser(AbstractParser, Base):
                     parsed_value = getattr(parsed_ns, key)
 
                 if argument is not None:
-                    if argument.secret and isinstance(parsed_value, str):
-                        parsed_value = SecretString(parsed_value)
+                    if argument.secret:
+                        if isinstance(parsed_value, str):
+                            parsed_value = SecretString(parsed_value)
+                        elif isinstance(parsed_value, (list, tuple)):
+                            # nargs secrets: wrap each element so a
+                            # repr of the list cannot leak the values.
+                            parsed_value = type(parsed_value)(
+                                SecretString(v) if isinstance(v, str) else v
+                                for v in parsed_value
+                            )
                     if argument.converter is not None:
                         if argument.nargs and parsed_value is None:
                             parsed_value = []

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -386,12 +386,14 @@ assert parser.database.port == 5432
 Rejected forms raise `ArgumentDefinitionError` immediately when the
 parser class is defined, with a hint suggesting the correct form.
 
-### Reusing a group instance is an error
+### Reusing a group instance
 
-Passing the same `Group` instance to two different attributes raises
-`ArgclassError`, because that group's parsed state would otherwise be
-shared between locations. Instantiate a separate group per attribute,
-or subclass `Group` to define a dedicated type:
+Group instances in a class body are prototypes — every parser
+instance works on its own copies, so the same `Group` instance may be
+bound to several attributes and each binding keeps independent parsed
+state. Separate instances per attribute remain the clearest style
+(and are required when the attributes need different `title`/`prefix`
+options):
 
 <!--- name: test_groups_nested_separate_instances --->
 ```python

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -251,8 +251,10 @@ disallowed.
 ## Subcommands
 
 When using subcommands, only the selected subcommand's arguments are parsed
-and populated. Other subcommands retain their default values. Don't assume
-all subcommand attributes are populated after parsing.
+and populated. Attributes of subcommands that were **not** selected are not
+populated at all — accessing them raises
+`AttributeError("... was not parsed")`. Don't assume all subcommand
+attributes are available after parsing.
 
 <!--- name: test_pitfall_subparser --->
 ```python
@@ -271,7 +273,12 @@ class CLI(argclass.Parser):
 cli = CLI()
 cli.parse_args(["serve", "--port", "9000"])
 assert cli.serve.port == 9000
-# cli.build.output is still default
+
+# `build` was not selected, so its arguments were never populated:
+try:
+    cli.build.output
+except AttributeError as e:
+    assert "was not parsed" in str(e)
 ```
 
 :::{tip}
@@ -285,6 +292,38 @@ automatically to the selected command.
 for internal parser state — using them as your own argument names raises
 `ArgumentDefinitionError`. See
 [Reserved Attribute Names](subparsers.md#reserved-attribute-names).
+The same applies to names of Parser API methods (`parse_args`,
+`print_help`, `sanitize_env`, `create_parser`, …) and to methods you
+define on your own parser classes: an argument cannot shadow them.
+:::
+
+:::{warning}
+Group and subparser attributes are **class-level singletons**: every
+instance of the same Parser class shares the same Group and subparser
+objects. A second `parse_args()` — whether on the same parser instance
+or on another instance of the same class — overwrites the group and
+subcommand values produced by the first one. When you need independent
+results (e.g. parsing several argv sets side by side), keep each
+result before the next parse, or define separate Parser classes.
+
+<!--- name: test_pitfall_shared_groups --->
+```python
+import argclass
+
+class DB(argclass.Group):
+    host: str = "localhost"
+
+class CLI(argclass.Parser):
+    db = DB()
+
+first = CLI()
+second = CLI()
+assert first.db is second.db  # the same Group object!
+
+first.parse_args(["--db-host", "from-first"])
+second.parse_args(["--db-host", "from-second"])
+assert first.db.host == "from-second"  # overwritten by the later parse
+```
 :::
 
 ---

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -211,11 +211,12 @@ class Parser(argclass.Parser):
 
 ### Reusing a Group instance across attributes
 
-Each `Group` instance owns the parsed state for one location in the
-parser tree. Assigning the **same instance** to two attributes raises
-`ArgclassError`, because parsed values would otherwise be shared
-between both locations.
+Group instances written in a class body are **prototypes**: every
+parser instance works on its own copies. That makes assigning the
+same instance to several attributes safe — each binding becomes an
+independent copy with its own parsed state:
 
+<!--- name: test_pitfall_group_instance_reuse --->
 ```python
 import argclass
 
@@ -225,26 +226,26 @@ class Credentials(argclass.Group):
 shared = Credentials()
 
 class Parser(argclass.Parser):
-    primary = shared      # OK on its own — single binding
-    secondary = shared    # Together with `primary`, raises ArgclassError
-                          # at parse_args time (same instance bound twice)
+    primary = shared
+    secondary = shared    # fine: each binding gets its own copy
+
+parser = Parser()
+parser.parse_args([
+    "--primary-username", "alice",
+    "--secondary-username", "bob",
+])
+assert parser.primary.username == "alice"
+assert parser.secondary.username == "bob"
 ```
 
-A single attribute bound to an externally-created Group is fine; the
-error only fires when the **same instance** is reachable through two
-or more attributes at parse time.
+Keep in mind that the copies inherit the prototype's `title`,
+`description`, and `prefix`. A reused instance with an explicit
+`prefix=` would produce conflicting CLI flags — give each attribute
+its own instance when they need different options.
 
-Create a separate instance for each attribute instead:
-
-```python
-class Parser(argclass.Parser):
-    primary = Credentials()      # RIGHT - distinct instances
-    secondary = Credentials()
-```
-
-Using the same `Group` **class** twice (with different `Group()` calls)
-is fully supported — only sharing one already-constructed instance is
-disallowed.
+The only forbidden shape is a **cycle** — a group that (directly or
+indirectly) contains itself raises `ArgclassError` at parser
+construction time.
 
 ---
 
@@ -297,14 +298,12 @@ The same applies to names of Parser API methods (`parse_args`,
 define on your own parser classes: an argument cannot shadow them.
 :::
 
-:::{warning}
-Group and subparser attributes are **class-level singletons**: every
-instance of the same Parser class shares the same Group and subparser
-objects. A second `parse_args()` — whether on the same parser instance
-or on another instance of the same class — overwrites the group and
-subcommand values produced by the first one. When you need independent
-results (e.g. parsing several argv sets side by side), keep each
-result before the next parse, or define separate Parser classes.
+:::{note}
+Every Parser instance works on its **own copies** of the declared
+groups and subparsers: the instances written in the class body are
+just prototypes. Parsing one parser instance never affects another
+one, and the prototypes stay pristine. Re-parsing the *same* parser
+instance overwrites its previous values, as expected.
 
 <!--- name: test_pitfall_shared_groups --->
 ```python
@@ -318,11 +317,12 @@ class CLI(argclass.Parser):
 
 first = CLI()
 second = CLI()
-assert first.db is second.db  # the same Group object!
+assert first.db is not second.db  # independent copies
 
 first.parse_args(["--db-host", "from-first"])
 second.parse_args(["--db-host", "from-second"])
-assert first.db.host == "from-second"  # overwritten by the later parse
+assert first.db.host == "from-first"  # not affected by the later parse
+assert second.db.host == "from-second"
 ```
 :::
 

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -516,6 +516,101 @@ class TestInheritedDefaultsPreserved:
         assert b.LIMIT == 5
 
 
+class TestPerInstanceState:
+    """Fix 6: groups and subparsers are copied per Parser instance,
+    so parsing one instance never mutates another (or the class-level
+    prototypes)."""
+
+    def test_groups_independent_across_instances(self):
+        class CLI(argclass.Parser):
+            db = SharedDB()
+
+        first = CLI()
+        second = CLI()
+        assert first.db is not second.db
+
+        first.parse_args(["--db-host", "from-first"])
+        second.parse_args(["--db-host", "from-second"])
+        assert first.db.host == "from-first"
+        assert second.db.host == "from-second"
+
+    def test_class_prototype_stays_pristine(self):
+        class CLI(argclass.Parser):
+            db = SharedDB()
+
+        prototype = CLI.__argument_groups__["db"]
+        cli = CLI()
+        cli.parse_args(["--db-host", "parsed"])
+        assert cli.db is not prototype
+        with pytest.raises(AttributeError):
+            prototype.host
+
+    def test_nested_groups_independent(self):
+        class Credentials(argclass.Group):
+            username: str = "admin"
+
+        class Endpoint(argclass.Group):
+            credentials: Credentials = Credentials()
+
+        class CLI(argclass.Parser):
+            endpoint: Endpoint = Endpoint()
+
+        first = CLI()
+        second = CLI()
+        first.parse_args(["--endpoint-credentials-username", "alice"])
+        second.parse_args(["--endpoint-credentials-username", "bob"])
+        assert first.endpoint.credentials.username == "alice"
+        assert second.endpoint.credentials.username == "bob"
+
+    def test_subparsers_independent_across_instances(self):
+        class CLI(argclass.Parser):
+            serve = SharedServe()
+
+        first = CLI()
+        second = CLI()
+        assert first.serve is not second.serve
+
+        first.parse_args(["serve", "--port", "1111"])
+        second.parse_args(["serve", "--port", "2222"])
+        assert first.serve.port == 1111
+        assert second.serve.port == 2222
+        assert first.current_subparser is first.serve
+        assert second.current_subparser is second.serve
+
+    def test_subparser_groups_independent(self):
+        class Sub(argclass.Parser):
+            db = SharedDB()
+
+        class CLI(argclass.Parser):
+            sub = Sub()
+
+        first = CLI()
+        second = CLI()
+        first.parse_args(["sub", "--db-host", "h1"])
+        second.parse_args(["sub", "--db-host", "h2"])
+        assert first.sub.db.host == "h1"
+        assert second.sub.db.host == "h2"
+
+    def test_reparse_same_instance_overwrites(self):
+        class CLI(argclass.Parser):
+            db = SharedDB()
+
+        cli = CLI()
+        cli.parse_args(["--db-host", "one"])
+        cli.parse_args(["--db-host", "two"])
+        assert cli.db.host == "two"
+
+    def test_group_options_preserved_on_copy(self):
+        class CLI(argclass.Parser):
+            db = SharedDB(prefix="dbx", defaults={"host": "preset"})
+
+        cli = CLI()
+        cli.parse_args([])
+        assert cli.db.host == "preset"
+        cli.parse_args(["--dbx-host", "cli-value"])
+        assert cli.db.host == "cli-value"
+
+
 class TestPathTypeUnchanged:
     """Sanity: Path defaults and types keep working end to end."""
 

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -1,0 +1,528 @@
+"""Regression tests for the source-audit fixes.
+
+Each test class covers one finding:
+
+1.  A single ``Argument()`` instance shared by several fields/classes
+    must not be mutated in place by the metaclass.
+2.  Arguments may not shadow methods/properties of the Parser API or
+    of user base classes.
+3.  ``serve: Serve`` (annotation without an instance) must raise
+    instead of silently becoming a CLI argument.
+4.  ``strict=False`` defaults parsers skip malformed files for every
+    format (INI/JSON/TOML); ``strict=True`` propagates the error.
+5.  ``Secret(nargs=...)`` wraps every list element in SecretString.
+8.  ``EnumArgument(lowercase=True)`` works for enums whose member
+    names are not fully uppercase; enum aliases stay accepted.
+9.  ``Optional[T]`` + bare ``Argument()`` still unwraps properly
+    (guards the dead-code removal around the optional unwrap).
+10. ``INIDefaultsParser.BOOL_TRUE_VALUES`` is the shared constant.
+11. ``ConfigAction`` caches an empty parse result (None sentinel).
+12. Unannotated arguments/groups/subparsers survive subclassing.
+"""
+
+import argparse
+import configparser
+import enum
+from pathlib import Path
+
+import pytest
+
+import argclass
+from argclass import SecretString
+from argclass.types import TEXT_TRUE_VALUES
+
+
+class SharedDB(argclass.Group):
+    host: str = "localhost"
+
+
+class SharedServe(argclass.Parser):
+    port: int = 8080
+
+
+class TestSharedArgumentInstance:
+    """Fix 1: copy-on-write before the metaclass infers type/nargs."""
+
+    def test_two_fields_same_class(self):
+        arg = argclass.Argument()
+
+        class P(argclass.Parser):
+            a: int = arg
+            b: str = arg
+
+        p = P()
+        p.parse_args(["--a", "5", "--b", "hello"])
+        assert p.a == 5
+        assert p.b == "hello"
+
+    def test_two_classes(self):
+        arg = argclass.Argument(help="shared")
+
+        class A(argclass.Parser):
+            x: int = arg
+
+        class B(argclass.Parser):
+            y: str = arg
+
+        b = B()
+        b.parse_args(["--y", "world"])
+        assert b.y == "world"
+
+        a = A()
+        a.parse_args(["--x", "3"])
+        assert a.x == 3
+
+    def test_user_instance_not_mutated(self):
+        arg = argclass.Argument()
+
+        class P(argclass.Parser):
+            a: int = arg
+
+        assert arg.type is None
+        assert arg.nargs is None
+        assert P.__arguments__["a"].type is int
+
+
+class TestApiShadowGuard:
+    """Fix 2: arguments may not clobber methods/properties."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["parse_args", "print_help", "sanitize_env", "create_parser"],
+    )
+    def test_annotated_field_rejected(self, name):
+        with pytest.raises(argclass.ArgumentDefinitionError) as exc_info:
+            type(
+                "Bad",
+                (argclass.Parser,),
+                {"__annotations__": {name: str}, name: "oops"},
+            )
+        assert "shadow" in str(exc_info.value)
+
+    def test_unannotated_argument_rejected(self):
+        with pytest.raises(argclass.ArgumentDefinitionError):
+
+            class Bad(argclass.Parser):
+                print_help = argclass.Argument()  # type: ignore[assignment]
+
+    def test_user_helper_method_protected(self):
+        class A(argclass.Parser):
+            def helper(self) -> int:
+                return 1
+
+        with pytest.raises(argclass.ArgumentDefinitionError):
+
+            class B(A):
+                helper: str = "x"  # type: ignore[assignment]
+
+    def test_own_body_method_and_annotation_rejected(self):
+        with pytest.raises(argclass.ArgumentDefinitionError):
+
+            class Bad(argclass.Parser):
+                handler: str = "x"
+
+                def handler(self) -> None:  # type: ignore[no-redef] # noqa: F811,E501
+                    pass
+
+    def test_overriding_inherited_argument_still_works(self):
+        class A(argclass.Parser):
+            x: int = 1
+
+        class B(A):
+            x: int = 2
+
+        b = B()
+        b.parse_args([])
+        assert b.x == 2
+
+    def test_overriding_inherited_group_still_works(self):
+        class A(argclass.Parser):
+            db = SharedDB()
+
+        class B(A):
+            db = SharedDB(title="other")
+
+        assert B.__argument_groups__["db"] is not A.__argument_groups__["db"]
+
+
+class TestAnnotationOnlySubparser:
+    """Fix 3: a Parser-class annotation without an instance raises."""
+
+    def test_bare_annotation_rejected(self):
+        with pytest.raises(argclass.ArgumentDefinitionError) as exc_info:
+
+            class CLI(argclass.Parser):
+                serve: SharedServe
+
+        message = str(exc_info.value)
+        assert "SharedServe" in message
+        assert "instance" in message
+
+    def test_optional_annotation_rejected(self):
+        with pytest.raises(argclass.ArgumentDefinitionError):
+
+            class CLI(argclass.Parser):
+                serve: SharedServe | None = None
+
+    def test_annotated_with_instance_works(self):
+        class CLI(argclass.Parser):
+            serve: SharedServe = SharedServe()
+
+        assert "serve" in CLI.__subparsers__
+        cli = CLI()
+        cli.parse_args(["serve", "--port", "9000"])
+        assert cli.serve.port == 9000
+
+
+class TestDefaultsParserStrictness:
+    """Fix 4: consistent strict/non-strict across INI/JSON/TOML."""
+
+    def test_malformed_toml_non_strict_skipped(self, tmp_path):
+        bad = tmp_path / "bad.toml"
+        bad.write_text("this is [[[ not toml")
+        parser = argclass.TOMLDefaultsParser([bad], strict=False)
+        assert dict(parser.parse()) == {}
+        assert parser.loaded_files == ()
+
+    def test_malformed_toml_strict_raises(self, tmp_path):
+        bad = tmp_path / "bad.toml"
+        bad.write_text("this is [[[ not toml")
+        parser = argclass.TOMLDefaultsParser([bad], strict=True)
+        with pytest.raises(ValueError):
+            parser.parse()
+
+    def test_malformed_ini_non_strict_skipped(self, tmp_path):
+        bad = tmp_path / "bad.ini"
+        bad.write_text("no section header\n")
+        good = tmp_path / "good.ini"
+        good.write_text("[sec]\nkey = value\n")
+        parser = argclass.INIDefaultsParser([bad, good], strict=False)
+        result = dict(parser.parse())
+        assert result["sec"] == {"key": "value"}
+        assert parser.loaded_files == (good,)
+
+    def test_malformed_ini_strict_raises(self, tmp_path):
+        bad = tmp_path / "bad.ini"
+        bad.write_text("no section header\n")
+        parser = argclass.INIDefaultsParser([bad], strict=True)
+        with pytest.raises(configparser.Error):
+            parser.parse()
+
+    def test_malformed_json_non_strict_skipped(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        parser = argclass.JSONDefaultsParser([bad], strict=False)
+        assert dict(parser.parse()) == {}
+
+
+class TestSecretSequences:
+    """Fix 5: nargs secrets are wrapped element-wise."""
+
+    def test_list_elements_masked(self):
+        class P(argclass.Parser):
+            keys: list[str] = argclass.Secret(nargs="+")
+
+        p = P()
+        p.parse_args(["--keys", "s3cret1", "s3cret2"])
+        assert all(isinstance(k, SecretString) for k in p.keys)
+        assert repr(p.keys) == "['******', '******']"
+        # The actual values stay accessible via str()
+        assert [str(k) for k in p.keys] == ["s3cret1", "s3cret2"]
+
+    def test_single_secret_still_masked(self):
+        class P(argclass.Parser):
+            token: str = argclass.Secret()
+
+        p = P()
+        p.parse_args(["--token", "t0ken"])
+        assert isinstance(p.token, SecretString)
+        assert repr(p.token) == "'******'"
+
+
+class TestEnumArgumentMixedCase:
+    """Fix 8: lowercase=True works for non-UPPERCASE member names."""
+
+    class Mode(enum.Enum):
+        Fast = 1
+        Slow = 2
+
+    def test_mixed_case_member_parses(self):
+        class P(argclass.Parser):
+            mode = argclass.EnumArgument(self.Mode, lowercase=True)
+
+        p = P()
+        p.parse_args(["--mode", "fast"])
+        assert p.mode is self.Mode.Fast
+
+    def test_mixed_case_string_default(self):
+        class P(argclass.Parser):
+            mode = argclass.EnumArgument(
+                self.Mode, lowercase=True, default="fast"
+            )
+
+        p = P()
+        p.parse_args([])
+        assert p.mode is self.Mode.Fast
+
+    def test_invalid_default_still_rejected(self):
+        with pytest.raises(argclass.EnumValueError):
+            argclass.EnumArgument(self.Mode, lowercase=True, default="warp")
+
+    def test_invalid_env_value_raises_conversion_error(self, monkeypatch):
+        # Env values bypass argparse ``choices`` validation, so the
+        # converter is the last line of defense for bad spellings.
+        monkeypatch.setenv("AUDIT_MODE", "warp")
+
+        class P(argclass.Parser):
+            mode = argclass.EnumArgument(
+                self.Mode, lowercase=True, env_var="AUDIT_MODE"
+            )
+
+        with pytest.raises(argclass.TypeConversionError):
+            P().parse_args([])
+
+    def test_enum_aliases_still_accepted(self):
+        # LogLevelEnum.WARN is an alias of WARNING; aliases are valid
+        # inputs even though choices list canonical names only.
+        class P(argclass.Parser):
+            log_level: int = argclass.LogLevel
+
+        p = P()
+        p.parse_args(["--log-level", "warning"])
+        assert p.log_level == 30
+
+
+class TestOptionalArgumentUnwrap:
+    """Fix 9 regression guard: Optional[T] + bare Argument() still
+    unwraps to T and stays optional after the dead-code removal."""
+
+    def test_optional_int_argument(self):
+        class P(argclass.Parser):
+            x: int | None = argclass.Argument()
+
+        p = P()
+        p.parse_args([])
+        assert p.x is None
+        p.parse_args(["--x", "5"])
+        assert p.x == 5
+        assert isinstance(p.x, int)
+
+
+class TestBoolValuesShared:
+    """Fix 10: the INI bool set is the shared TEXT_TRUE_VALUES."""
+
+    def test_alias(self):
+        assert argclass.INIDefaultsParser.BOOL_TRUE_VALUES is TEXT_TRUE_VALUES
+
+
+class TestConfigActionCache:
+    """Fix 11: empty parse results are cached via the None sentinel."""
+
+    class CountingAction(argclass.INIConfigAction):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+            self.parse_calls = 0
+
+        def parse(self, *files: Path) -> dict:
+            self.parse_calls += 1
+            return {}
+
+    def test_empty_result_not_reparsed(self, tmp_path):
+        config = tmp_path / "app.ini"
+        config.write_text("[DEFAULT]\n")
+        action = self.CountingAction(
+            option_strings=["--config"],
+            dest="config",
+        )
+        parser = argparse.ArgumentParser()
+        namespace = argparse.Namespace()
+
+        action(parser, namespace, str(config))
+        # Second invocation passes the already-set mapping back in, as
+        # Parser.parse_args does; the cached empty result must be used.
+        action(parser, namespace, getattr(namespace, "config"))
+        assert action.parse_calls == 1
+        assert dict(namespace.config) == {}
+
+
+class TestUnannotatedInheritance:
+    """Fix 12: unannotated members survive subclassing."""
+
+    def test_subclass_inherits_everything(self):
+        class A(argclass.Parser):
+            tags = argclass.Argument(nargs="+", type=str)
+            db = SharedDB()
+            serve = SharedServe()
+            name: str = "x"
+
+        class B(A):
+            extra: int = 1
+
+        assert set(B.__arguments__) == {"tags", "name", "extra"}
+        assert set(B.__argument_groups__) == {"db"}
+        assert set(B.__subparsers__) == {"serve"}
+
+        b = B()
+        b.parse_args(
+            [
+                "--tags",
+                "t1",
+                "t2",
+                "--db-host",
+                "example.com",
+                "--extra",
+                "7",
+                "serve",
+                "--port",
+                "9000",
+            ],
+        )
+        assert b.tags == ["t1", "t2"]
+        assert b.db.host == "example.com"
+        assert b.extra == 7
+        assert b.serve.port == 9000
+
+    def test_subclass_overrides_unannotated_argument(self):
+        class A(argclass.Parser):
+            tags = argclass.Argument(nargs="+", type=str)
+
+        class B(A):
+            tags = argclass.Argument(nargs="+", type=int)
+
+        b = B()
+        b.parse_args(["--tags", "1", "2"])
+        assert b.tags == [1, 2]
+
+    def test_grandchild_inherits_through_chain(self):
+        class A(argclass.Parser):
+            serve = SharedServe()
+
+        class B(A):
+            pass
+
+        class C(B):
+            flag: bool = False
+
+        assert "serve" in C.__subparsers__
+
+    def test_category_change_drops_stale_entry(self):
+        class A(argclass.Parser):
+            item = argclass.Argument(type=str)
+
+        class B(A):
+            item = SharedDB()  # type: ignore[assignment]
+
+        assert "item" not in B.__arguments__
+        assert "item" in B.__argument_groups__
+
+
+class TestInheritedDefaultsPreserved:
+    """Fix 13: plain annotated defaults survive subclassing.
+
+    The metaclass replaces processed class attributes with ``...``
+    placeholders, so rebuilding an inherited field from its annotation
+    used to turn ``name: str = "x"`` into a *required* argument in
+    every subclass.
+    """
+
+    def test_inherited_default_kept(self):
+        class A(argclass.Parser):
+            name: str = "x"
+
+        class B(A):
+            extra: int = 1
+
+        b = B()
+        b.parse_args([])
+        assert b.name == "x"
+        assert b.extra == 1
+
+    def test_subclass_can_still_override_default(self):
+        class A(argclass.Parser):
+            name: str = "x"
+
+        class B(A):
+            name: str = "y"
+
+        b = B()
+        b.parse_args([])
+        assert b.name == "y"
+
+    def test_subclass_value_only_override(self):
+        # Re-assigning without re-annotating must also re-apply.
+        class A(argclass.Parser):
+            name: str = "x"
+
+        class B(A):
+            name = "z"
+
+        b = B()
+        b.parse_args([])
+        assert b.name == "z"
+
+    def test_inherited_required_field_stays_required(self):
+        class A(argclass.Parser):
+            name: str
+
+        class B(A):
+            extra: int = 1
+
+        with pytest.raises(SystemExit):
+            B().parse_args(["--extra", "2"])
+        b = B()
+        b.parse_args(["--name", "n"])
+        assert b.name == "n"
+
+    def test_reannotation_without_value_resets_default(self):
+        # Re-declaring the annotation (without assigning a value)
+        # rebuilds the field from scratch: the base class attribute is
+        # an ``...`` placeholder, so the field becomes required again.
+        class A(argclass.Parser):
+            name: str = "x"
+
+        class B(A):
+            name: str
+
+        with pytest.raises(SystemExit):
+            B().parse_args([])
+        b = B()
+        b.parse_args(["--name", "n"])
+        assert b.name == "n"
+
+    def test_reannotated_bool_reuses_inherited_argument(self):
+        class A(argclass.Parser):
+            flag: bool = False
+
+        class B(A):
+            flag: bool
+
+        b = B()
+        b.parse_args([])
+        assert b.flag is False
+        b.parse_args(["--flag"])
+        assert b.flag is True
+
+    def test_annotating_plain_base_constant(self):
+        # A plain (non-callable) class attribute on the base is a
+        # legitimate source for an annotated field's default.
+        class A(argclass.Parser):
+            LIMIT = 5
+
+        class B(A):
+            LIMIT: int
+
+        b = B()
+        b.parse_args([])
+        assert b.LIMIT == 5
+
+
+class TestPathTypeUnchanged:
+    """Sanity: Path defaults and types keep working end to end."""
+
+    def test_path_argument(self):
+        class P(argclass.Parser):
+            target: Path = argclass.Argument(type=Path, default=Path("/tmp"))
+
+        p = P()
+        p.parse_args(["--target", "/var"])
+        assert p.target == Path("/var")

--- a/tests/test_nested_groups.py
+++ b/tests/test_nested_groups.py
@@ -530,7 +530,10 @@ class TestGroupAnnotation:
 
 
 class TestSameInstanceReuse:
-    def test_reused_group_instance_raises(self):
+    def test_reused_group_instance_cloned_independently(self):
+        # Every binding gets its own per-parser-instance copy, so the
+        # same Group instance may be assigned to several attributes —
+        # each location keeps independent parsed state.
         shared = Credentials()
 
         class Outer(argclass.Group):
@@ -541,9 +544,35 @@ class TestSameInstanceReuse:
             outer: Outer = Outer()
 
         parser = App()
-        with pytest.raises(ArgclassError) as exc_info:
-            parser.parse_args([])
-        assert "referenced more than once" in str(exc_info.value)
+        assert parser.outer.primary is not parser.outer.secondary
+        parser.parse_args(
+            [
+                "--outer-primary-username=alice",
+                "--outer-secondary-username=bob",
+            ],
+        )
+        assert parser.outer.primary.username == "alice"
+        assert parser.outer.secondary.username == "bob"
+        # The shared prototype itself is untouched.
+        with pytest.raises(AttributeError):
+            shared.username
+
+    def test_reused_instance_at_parser_level(self):
+        shared = Credentials()
+
+        class App(argclass.Parser):
+            primary: Credentials = shared
+            secondary: Credentials = shared
+
+        parser = App()
+        parser.parse_args(
+            [
+                "--primary-username=alice",
+                "--secondary-username=bob",
+            ],
+        )
+        assert parser.primary.username == "alice"
+        assert parser.secondary.username == "bob"
 
     def test_three_link_cycle_raises(self):
         """A → B → C → A. Synthetic — normal class syntax can't form
@@ -573,9 +602,8 @@ class TestSameInstanceReuse:
             class P(argclass.Parser):
                 root: A = a
 
-            parser = P()
             with pytest.raises(ArgclassError) as exc_info:
-                parser.parse_args([])
+                P()
             assert "referenced more than once" in str(exc_info.value)
             assert "root.b.c.a" in str(exc_info.value)
         finally:
@@ -598,12 +626,29 @@ class TestSameInstanceReuse:
             class P(argclass.Parser):
                 root: Loop = instance
 
-            parser = P()
             with pytest.raises(ArgclassError) as exc_info:
-                parser.parse_args([])
+                P()
             assert "referenced more than once" in str(exc_info.value)
         finally:
             Loop.__argument_groups__ = MappingProxyType({})
+
+    def test_post_init_cycle_caught_at_parse(self):
+        """Cycles wired into the per-instance mappings after
+        construction are caught by the parse-time backstop."""
+        from types import MappingProxyType
+
+        class G(argclass.Group):
+            foo: int = 1
+
+        class P(argclass.Parser):
+            root: G = G()
+
+        parser = P()
+        clone = parser.root
+        clone.__argument_groups__ = MappingProxyType({"again": clone})
+        with pytest.raises(ArgclassError) as exc_info:
+            parser.parse_args([])
+        assert "referenced more than once" in str(exc_info.value)
 
     def test_two_distinct_instances_of_same_class_ok(self):
         class Outer(argclass.Group):
@@ -625,8 +670,7 @@ class TestSameInstanceReuse:
 
     def test_single_external_instance_bound_once_ok(self):
         """An externally-created Group instance assigned to a single
-        attribute is fine. The reuse check only fires when the same
-        instance is bound to two or more attributes."""
+        attribute is fine; the parser works on its own copy."""
         shared = Credentials()
 
         class P(argclass.Parser):
@@ -635,4 +679,8 @@ class TestSameInstanceReuse:
         parser = P()
         parser.parse_args(["--primary-username=alice"])
         assert parser.primary.username == "alice"
-        assert parser.primary is shared
+        # The parser works on its own per-instance copy; the class
+        # body prototype stays pristine.
+        assert parser.primary is not shared
+        with pytest.raises(AttributeError):
+            shared.username


### PR DESCRIPTION
## Summary

Two changes on top of 1.10.0: a batch of fixes for latent bugs found by a
full-source audit, and a behavioral improvement that gives every Parser
instance its own copies of declared groups and subparsers.

## Audit fixes (13 findings, each verified by a failing test against the pre-fix code)

**Metaclass:**
- A shared `Argument()` instance bound to several fields/classes was mutated
  in place — `b: str = arg` silently required the `int` inferred for `a: int`.
  The metaclass now copies before inferring type/nargs/choices.
- Arguments can no longer shadow methods/properties (`parse_args`,
  `print_help`, user-defined helpers): previously they were silently replaced
  with `...` placeholders, destroying the parser API.
- A bare `serve: Serve` annotation (no instance) raises instead of silently
  becoming a required CLI argument with `type=<Parser class>`.
- Subclasses now inherit unannotated arguments, groups, and subparsers
  (previously a subclass lost every `tags = Argument(...)` / `db = DB()` /
  `serve = Serve()` from its base).
- Inherited plain defaults are preserved: `name: str = "x"` no longer becomes
  a *required* argument in subclasses.
- `Secret(nargs=...)` wraps each list element in `SecretString` (repr no
  longer leaks values).

**Config parsers:**
- Consistent `strict=False`: malformed INI/TOML files are skipped like JSON
  instead of raising; `strict=True` still propagates.
- `INIDefaultsParser.BOOL_TRUE_VALUES` aliases the shared
  `types.TEXT_TRUE_VALUES`.
- `ConfigAction` caches via a `None` sentinel (an empty config parses once).

**Factory:**
- `EnumArgument(lowercase=True)` uses an explicit name map instead of
  `str.upper()` round-trips, fixing enums with non-uppercase member names;
  enum aliases (`WARN` → `WARNING`) remain accepted.

**Docs:** corrected the false claim that unselected subcommands "retain their
default values" (they raise `AttributeError`).

## Per-instance copies & group reuse

`Parser.__init__` now clones the declared member tree (recursively for nested
groups and subparser trees), so:

- Parsing one parser instance never overwrites another instance's group or
  subcommand values; the class-body instances become pristine prototypes.
- Assigning **one Group instance to several attributes is now supported** —
  each binding is an independent copy. Only cyclic group trees raise
  (at construction time, with a parse-time backstop).

### Behavior changes to note

- `parser.group` is no longer the class-body instance; module-level references
  to a Group/subparser must read values via the parser instance.
- The cycle error fires at `Parser()` construction instead of `parse_args()`.
- Name collisions with the Parser API now fail fast at class definition
  (such parsers could not work correctly before).

## Verification

- 706 tests (incl. 50+ new regression tests), green on Python 3.10–3.14.
- ruff check/format clean; mypy clean (pre-existing `tomllib` baseline only);
  coverage at the 100% gate.
- Docs blocks executable and passing; Sphinx builds without warnings.