### PR TITLE
Add config_argument: user-supplied config file as argument defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 ## What is argclass
 
-Declarative CLI parser for Python over `argparse`. Type hints → CLI args automatically. `str`→string, `bool`→flag, `Optional[T]`→optional, `list[T]`→multi-value, `Literal[...]`→choices. Priority: defaults < config files < env vars < CLI args. Zero deps, stdlib only, Python 3.10-3.14.
+Declarative CLI parser for Python over `argparse`. Type hints → CLI args automatically. `str`→string, `bool`→flag, `Optional[T]`→optional, `list[T]`→multi-value, `Literal[...]`→choices. Priority: defaults < config files < `config_argument` file < env vars < CLI args. Zero deps, stdlib only, Python 3.10-3.14.
+
+`Parser(config_argument="--config")` adds a CLI flag whose file becomes argument defaults at invocation time (two-pass parsing); `config_files=` is the developer-preset equivalent.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,32 @@ parser = Parser(config_files=[
 ])
 ```
 
+To let the **end user** choose the config file, add
+`config_argument="--config"` — the flag's file becomes argument
+defaults (CLI and env vars still win):
+
+<!--- name: test_config_argument_example --->
+```python
+import argclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+class Parser(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+
+with NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+    f.write("[DEFAULT]\nhost = example.com\nport = 9000\n")
+    config_path = f.name
+
+parser = Parser(config_argument="--config")
+parser.parse_args(["--config", config_path, "--port", "1234"])
+assert parser.host == "example.com"   # default from the file
+assert parser.port == 1234            # CLI still wins
+
+Path(config_path).unlink()
+```
+
 ### Environment Variables
 
 <!--- name: test_env_example --->

--- a/argclass/actions.py
+++ b/argclass/actions.py
@@ -76,7 +76,10 @@ class ConfigAction(Action):
         if self._result is None:
             filenames: Sequence[Path] = list(self.search_paths)
             if values:
-                filenames = [Path(values)] + list(filenames)
+                # The explicitly passed file goes LAST: parse() merges
+                # files in order with dict.update(), so later files
+                # win and an explicit --config overrides search_paths.
+                filenames = list(filenames) + [Path(values)]
             filenames = list(filter(lambda x: x.exists(), filenames))
 
             if self.required and not filenames:

--- a/argclass/parser.py
+++ b/argclass/parser.py
@@ -2,6 +2,7 @@
 
 import copy
 import os
+import sys
 import weakref
 from abc import ABCMeta
 from argparse import Action, ArgumentParser
@@ -26,6 +27,7 @@ from .exceptions import (
     ArgclassError,
     ArgumentDefinitionError,
     ComplexTypeError,
+    ConfigurationError,
     TypeConversionError,
 )
 from .secret import SecretString
@@ -618,6 +620,22 @@ def _clone_group_tree(
 ParserType = TypeVar("ParserType", bound="Parser")
 
 
+class PreScanError(Exception):
+    """Raised instead of SystemExit by the config pre-scan parser."""
+
+
+class PreScanParser(ArgumentParser):
+    """ArgumentParser that neither prints to stderr nor exits.
+
+    Used for the lightweight first pass that only extracts the
+    ``config_argument`` value from argv; any syntax problem is left
+    for the real parser to report with the full usage text.
+    """
+
+    def error(self, message: str) -> Any:  # type: ignore[override]
+        raise PreScanError(message)
+
+
 # Out-of-band back-references: argparse_parser -> argclass Parser.
 # Lets custom actions (e.g. ``GenerateConfigAction``) recover the
 # argclass Parser without mutating any argparse object. Auto-cleans
@@ -749,11 +767,61 @@ class Parser(AbstractParser, Base):
         auto_env_var_prefix: str | None = None,
         strict_config: bool = False,
         config_parser_class: type[AbstractDefaultsParser] = INIDefaultsParser,
+        config_argument: str | Iterable[str] | None = None,
         **kwargs: Any,
     ):
+        """
+        Args:
+            config_files: Paths the DEVELOPER presets; existing files
+                are read at construction time and their values become
+                argument defaults (later files override earlier ones).
+            auto_env_var_prefix: Derive an environment variable name
+                for every argument (``PREFIX_ARG_NAME``); env values
+                override config-file defaults.
+            strict_config: Raise on malformed ``config_files`` instead
+                of skipping them.
+            config_parser_class: Format for both ``config_files`` and
+                ``config_argument`` (INI by default; pass
+                ``JSONDefaultsParser`` / ``TOMLDefaultsParser`` or a
+                custom ``AbstractDefaultsParser`` subclass).
+            config_argument: CLI flag (or several aliases, e.g.
+                ``("-c", "--config")``) that lets the END USER point
+                at a config file whose values become argument
+                defaults. Resolved before the main parse, so
+                ``--help`` reflects the file and required arguments
+                are satisfied by it. Priority: declared defaults <
+                ``config_files`` < ``config_argument`` file < env
+                vars < CLI args. An explicitly passed path that is
+                missing or unparsable raises ``ConfigurationError``.
+            kwargs: Passed through to ``argparse.ArgumentParser``
+                (e.g. ``prog``, ``description``, ``epilog``).
+        """
         super().__init__()
         self.current_subparsers: tuple[AbstractParser, ...] = ()
         self._config_files = config_files
+
+        # ``config_argument`` adds a CLI flag (e.g. "--config") that
+        # lets the END USER point at a config file whose values become
+        # argument defaults — same effect as ``config_files``, but the
+        # path is chosen at invocation time. Same format/parser class.
+        if config_argument is None:
+            self._config_argument: tuple[str, ...] = ()
+        elif isinstance(config_argument, str):
+            self._config_argument = (config_argument,)
+        else:
+            self._config_argument = tuple(config_argument)
+        for alias in self._config_argument:
+            if not alias.startswith("-"):
+                raise ArgumentDefinitionError(
+                    f"config_argument aliases must be optional flags "
+                    f"(start with '-'), got {alias!r}",
+                    aliases=self._config_argument,
+                    hint='Use config_argument="--config" or a tuple '
+                    'of flags like ("-c", "--config").',
+                )
+        self._config_parser_class = config_parser_class
+        self._runtime_config_parsers: list[AbstractDefaultsParser] = []
+        self._user_config_files: tuple[Path, ...] = ()
 
         # Parse config files using the specified parser class
         self._config_parser = config_parser_class(
@@ -828,6 +896,82 @@ class Parser(AbstractParser, Base):
             return None
         return self.current_subparsers[0]
 
+    @property
+    def loaded_config_files(self) -> tuple[Path, ...]:
+        """Configuration files whose values were applied as defaults:
+        constructor ``config_files`` first, then the file passed via
+        ``config_argument`` (highest priority last)."""
+        return tuple(self._config_parser.loaded_files) + self._user_config_files
+
+    def _scan_config_argument(self, argv: list[str]) -> str | None:
+        """First pass over argv: extract only the config flag value.
+
+        Defaults must be known before the real parser is built, but
+        the config path is itself a CLI argument — the classic
+        chicken-and-egg of argparse. A throwaway parser that knows
+        only the config flag resolves it.
+        """
+        prescan = PreScanParser(add_help=False)
+        prescan.add_argument(*self._config_argument, dest="path", default=None)
+        try:
+            namespace, _ = prescan.parse_known_args(argv)
+        except PreScanError:
+            # Malformed usage (e.g. the flag without a value); the
+            # real parser will report it with the proper usage text.
+            return None
+        return namespace.path
+
+    def _load_config_argument(
+        self, argv: list[str]
+    ) -> list[AbstractDefaultsParser]:
+        if not self._config_argument:
+            return []
+        self._user_config_files = ()
+        path = self._scan_config_argument(argv)
+        if path is None:
+            return []
+        file = Path(path).expanduser()
+        # The user asked for this file explicitly, so problems are
+        # loud errors — unlike constructor ``config_files``, which
+        # are a search list where absent files are normal.
+        runtime_parser = self._config_parser_class([file], strict=True)
+        try:
+            runtime_parser.parse()
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise ConfigurationError(
+                f"failed to parse configuration file: {e}",
+                file_path=str(file),
+            ) from e
+        if not runtime_parser.loaded_files:
+            raise ConfigurationError(
+                "configuration file does not exist or is not readable",
+                file_path=str(file),
+                hint="Check the path passed via "
+                f"{'/'.join(self._config_argument)}.",
+            )
+        self._user_config_files = runtime_parser.loaded_files
+        return [runtime_parser]
+
+    def _get_config_default(
+        self,
+        name: str,
+        kind: ValueKind,
+        section: str | None = None,
+    ) -> Any:
+        """Look up a config-provided default for ``name``.
+
+        The file passed via ``config_argument`` (when present) wins
+        over the constructor ``config_files``; env vars and CLI args
+        still override both later in the chain.
+        """
+        for runtime_parser in self._runtime_config_parsers:
+            value = runtime_parser.get_value(name, kind, section=section)
+            if value is not None:
+                return value
+        return self._config_parser.get_value(name, kind, section=section)
+
     def _make_parser(
         self,
         parser: ArgumentParser | None = None,
@@ -840,6 +984,15 @@ class Parser(AbstractParser, Base):
             )
 
         _argclass_back_refs[parser] = self
+
+        if self._config_argument:
+            parser.add_argument(
+                *self._config_argument,
+                default=None,
+                metavar="FILE",
+                help="Read default values for the other arguments "
+                "from this configuration file",
+            )
 
         destinations: DestinationsType = defaultdict(set)
         self._fill_arguments(destinations, parser)
@@ -893,7 +1046,7 @@ class Parser(AbstractParser, Base):
 
             # Get default from config with type-aware loading
             kind = self._get_value_kind(argument)
-            config_default = self._config_parser.get_value(name, kind)
+            config_default = self._get_config_default(name, kind)
 
             # Apply type converter to config values
             if config_default is not None and argument.type is not None:
@@ -992,7 +1145,7 @@ class Parser(AbstractParser, Base):
 
             # Get default from config with type-aware loading
             kind = self._get_value_kind(argument)
-            config_default = self._config_parser.get_value(
+            config_default = self._get_config_default(
                 name,
                 kind,
                 section=section,
@@ -1099,8 +1252,20 @@ class Parser(AbstractParser, Base):
         args: list[str] | None = None,
         sanitize_secrets: bool = False,
     ) -> ParserType:
-        parser, destinations = self._make_parser()
-        parsed_ns = parser.parse_args(args=args)
+        argv = list(args) if args is not None else sys.argv[1:]
+        # Two-pass parsing: resolve the ``config_argument`` file first
+        # so its values are already baked in as argument defaults when
+        # the real parser is built (this also makes ``--help`` show
+        # the file-provided defaults). The runtime layer lives only
+        # for the duration of this parse.
+        try:
+            self._runtime_config_parsers = self._load_config_argument(
+                argv,
+            )
+            parser, destinations = self._make_parser()
+            parsed_ns = parser.parse_args(args=argv)
+        finally:
+            self._runtime_config_parsers = []
 
         # Get the chain of selected subparsers from the namespace
         selected_subparsers: tuple[AbstractParser, ...] = getattr(

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Repo-wide pytest configuration."""
+
+import os
+
+# Python 3.14+ argparse colorizes usage/help output; CI sets
+# FORCE_COLOR=1, which would inject ANSI escapes into captured output
+# and break substring assertions on help text. PYTHON_COLORS takes
+# precedence over FORCE_COLOR/NO_COLOR, pinning plain output
+# deterministically for every Python version and environment.
+os.environ["PYTHON_COLORS"] = "0"

--- a/docs/api.md
+++ b/docs/api.md
@@ -202,8 +202,11 @@ Path(config_path).unlink()
 ```
 
 :::{tip}
-For loading defaults into parser attributes, use `config_files` parameter instead.
-See [Config File Parsers](#config-file-parsers).
+For loading defaults into parser attributes, use the `config_files`
+parameter (developer-chosen paths) or `config_argument="--config"`
+(end-user-chosen path) instead. See
+[Config Files](config-files.md#user-supplied-config-file-config_argument)
+and [Config File Parsers](#config-file-parsers).
 :::
 
 ```{eval-rst}

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -39,6 +39,58 @@ assert parser.debug is True
 Path(config_path).unlink()
 ```
 
+## User-Supplied Config File (`config_argument`)
+
+`config_files=` is chosen by the developer at construction time. To
+let the **end user** point at a config file, pass
+`config_argument="--config"` — argclass adds the flag and applies the
+file's values as argument defaults via two-pass parsing (the flag is
+resolved first, then the real parser is built with the defaults in
+place, so even `--help` shows them):
+
+<!--- name: test_config_argument --->
+```python
+import argclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+class Parser(argclass.Parser):
+    host: str = "localhost"
+    port: int = 8080
+
+with NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+    f.write("[DEFAULT]\nhost = example.com\nport = 9000\n")
+    config_path = f.name
+
+parser = Parser(config_argument="--config")
+parser.parse_args(["--config", config_path, "--port", "1234"])
+
+assert parser.host == "example.com"   # default from the file
+assert parser.port == 1234            # CLI still wins
+
+Path(config_path).unlink()
+```
+
+Details:
+
+- The priority chain extends naturally: declared defaults <
+  `config_files` < `config_argument` file < env vars < CLI args.
+- The file format is the shared `config_parser_class` (INI by
+  default; pass `JSONDefaultsParser` / `TOMLDefaultsParser` for other
+  formats).
+- A required argument is satisfied by a value from the file.
+- Several aliases are accepted: `config_argument=("-c", "--config")`.
+- An explicitly passed path that does not exist or cannot be parsed
+  raises `ConfigurationError` — unlike `config_files`, which is a
+  lenient search list.
+- `parser.loaded_config_files` reports which files were applied, in
+  priority order.
+- The flag is resolved by the parser whose `parse_args()` you call;
+  put it before any subcommand on the command line.
+
+This is different from `argclass.Config()`, which loads a file into
+an attribute as raw data without touching other arguments' defaults.
+
 ## Supported Formats
 
 ::::{grid} 3

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,9 @@ and seamless integration with configuration files and environment variables.
 - **Multiple config formats** - Load defaults from INI, JSON, or TOML configuration
   files with automatic type conversion. Each format has built-in support with
   no additional dependencies (TOML requires Python 3.11+ or `tomli` package).
+- **User-supplied config** - `config_argument="--config"` adds a CLI flag so
+  the end user can point at a config file whose values become argument
+  defaults at invocation time.
 - **Environment variables** - Read configuration from environment variables
   with optional prefix support for namespacing.
 - **Secret handling** - Built-in support for sensitive values that are masked

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -449,6 +449,7 @@ type mismatches raise `ConfigurationError`.
 | Malformed INI/JSON/TOML | `ConfigurationError` with file path |
 | Value doesn't match type | `ConfigurationError` with field and section |
 | Missing file | Silently ignored (unless `strict_config=True`) |
+| Missing/malformed `config_argument` file | Always `ConfigurationError` (the user asked for it explicitly) |
 
 <!--- name: test_pitfall_config_ok --->
 ```python

--- a/tests/test_config_argument.py
+++ b/tests/test_config_argument.py
@@ -1,0 +1,257 @@
+"""Tests for the ``config_argument`` Parser constructor parameter.
+
+``config_argument="--config"`` adds a CLI flag that lets the end user
+point at a configuration file whose values become argument defaults —
+the same effect as the developer-supplied ``config_files``, resolved
+at invocation time via two-pass parsing.
+
+Priority chain: declared defaults < config_files < --config file
+< env vars < CLI args.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import argclass
+
+
+class DB(argclass.Group):
+    host: str = "localhost"
+    port: int = 5432
+
+
+class Credentials(argclass.Group):
+    username: str = "admin"
+
+
+class Endpoint(argclass.Group):
+    credentials: Credentials = Credentials()
+
+
+def make_cli() -> type:
+    class CLI(argclass.Parser):
+        debug: bool = False
+        workers: int = 1
+        tags: list[str] = argclass.Argument(
+            nargs=argclass.Nargs.ZERO_OR_MORE, default=[]
+        )
+        db: DB = DB()
+
+    return CLI
+
+
+@pytest.fixture
+def ini_config(tmp_path) -> Path:
+    config = tmp_path / "app.ini"
+    config.write_text(
+        "[DEFAULT]\n"
+        "workers = 8\n"
+        "debug = true\n"
+        "tags = ['a', 'b']\n"
+        "[db]\n"
+        "host = db.example.com\n"
+    )
+    return config
+
+
+class TestDefaultsFromConfigArgument:
+    def test_values_become_defaults(self, ini_config):
+        cli = make_cli()(config_argument="--config")
+        cli.parse_args(["--config", str(ini_config)])
+        assert cli.workers == 8
+        assert cli.debug is True
+        assert cli.tags == ["a", "b"]
+        assert cli.db.host == "db.example.com"
+        assert cli.db.port == 5432  # untouched: declared default
+
+    def test_equals_form_and_aliases(self, ini_config):
+        cli = make_cli()(config_argument=("-c", "--config"))
+        cli.parse_args([f"--config={ini_config}"])
+        assert cli.workers == 8
+
+        cli = make_cli()(config_argument=("-c", "--config"))
+        cli.parse_args(["-c", str(ini_config)])
+        assert cli.workers == 8
+
+    def test_nested_group_sections(self, tmp_path):
+        config = tmp_path / "app.ini"
+        config.write_text("[endpoint.credentials]\nusername = root\n")
+
+        class CLI(argclass.Parser):
+            endpoint: Endpoint = Endpoint()
+
+        cli = CLI(config_argument="--config")
+        cli.parse_args(["--config", str(config)])
+        assert cli.endpoint.credentials.username == "root"
+
+    def test_required_argument_satisfied_by_config(self, tmp_path):
+        config = tmp_path / "app.ini"
+        config.write_text("[DEFAULT]\nname = from-config\n")
+
+        class CLI(argclass.Parser):
+            name: str
+
+        cli = CLI(config_argument="--config")
+        cli.parse_args(["--config", str(config)])
+        assert cli.name == "from-config"
+
+        # Without the config the argument is still required.
+        with pytest.raises(SystemExit):
+            CLI(config_argument="--config").parse_args([])
+
+    def test_json_parser_class(self, tmp_path):
+        config = tmp_path / "app.json"
+        config.write_text(
+            json.dumps({"workers": 9, "db": {"host": "json-host"}}),
+        )
+        cli = make_cli()(
+            config_argument="--config",
+            config_parser_class=argclass.JSONDefaultsParser,
+        )
+        cli.parse_args(["--config", str(config)])
+        assert cli.workers == 9
+        assert cli.db.host == "json-host"
+
+
+class TestPriorityChain:
+    def test_cli_overrides_config(self, ini_config):
+        cli = make_cli()(config_argument="--config")
+        cli.parse_args(["--config", str(ini_config), "--workers", "2"])
+        assert cli.workers == 2
+
+    def test_env_overrides_config(self, ini_config, monkeypatch):
+        monkeypatch.setenv("APP_WORKERS", "5")
+        cli = make_cli()(
+            config_argument="--config",
+            auto_env_var_prefix="APP_",
+        )
+        cli.parse_args(["--config", str(ini_config)])
+        assert cli.workers == 5
+
+    def test_config_argument_overrides_config_files(self, ini_config, tmp_path):
+        ctor = tmp_path / "ctor.ini"
+        ctor.write_text("[DEFAULT]\nworkers = 3\n")
+        cli = make_cli()(
+            config_files=[ctor],
+            config_argument="--config",
+        )
+        cli.parse_args(["--config", str(ini_config)])
+        assert cli.workers == 8
+
+    def test_config_files_still_used_for_missing_keys(
+        self, ini_config, tmp_path
+    ):
+        ctor = tmp_path / "ctor.ini"
+        ctor.write_text("[DEFAULT]\nworkers = 3\n[db]\nport = 9999\n")
+        cli = make_cli()(
+            config_files=[ctor],
+            config_argument="--config",
+        )
+        cli.parse_args(["--config", str(ini_config)])
+        # db.port comes from the constructor config (absent in user's)
+        assert cli.db.port == 9999
+        assert cli.db.host == "db.example.com"
+
+
+class TestLifecycle:
+    def test_no_flag_passed_keeps_declared_defaults(self):
+        cli = make_cli()(config_argument="--config")
+        cli.parse_args([])
+        assert cli.workers == 1
+
+    def test_no_staleness_between_parses(self, ini_config):
+        cli = make_cli()(config_argument="--config")
+        cli.parse_args(["--config", str(ini_config)])
+        assert cli.workers == 8
+        cli.parse_args([])
+        assert cli.workers == 1
+
+    def test_loaded_config_files_property(self, ini_config, tmp_path):
+        ctor = tmp_path / "ctor.ini"
+        ctor.write_text("[DEFAULT]\nworkers = 3\n")
+        cli = make_cli()(
+            config_files=[ctor],
+            config_argument="--config",
+        )
+        cli.parse_args(["--config", str(ini_config)])
+        assert cli.loaded_config_files == (ctor, ini_config)
+
+    def test_flag_appears_in_help(self, capsys):
+        cli = make_cli()(config_argument="--config")
+        cli.print_help()
+        out = capsys.readouterr().out
+        assert "--config FILE" in out
+
+
+class TestErrors:
+    def test_missing_explicit_file_raises(self):
+        cli = make_cli()(config_argument="--config")
+        with pytest.raises(argclass.ConfigurationError) as exc_info:
+            cli.parse_args(["--config", "/no/such/file.ini"])
+        assert "/no/such/file.ini" in str(exc_info.value)
+
+    def test_malformed_explicit_file_raises(self, tmp_path):
+        bad = tmp_path / "bad.ini"
+        bad.write_text("this is not an ini file at all\n")
+        cli = make_cli()(config_argument="--config")
+        with pytest.raises(argclass.ConfigurationError):
+            cli.parse_args(["--config", str(bad)])
+
+    def test_positional_config_argument_rejected(self):
+        with pytest.raises(argclass.ArgumentDefinitionError):
+            make_cli()(config_argument="config")
+
+    def test_custom_parser_configuration_error_passes_through(self, tmp_path):
+        # A custom defaults parser raising ConfigurationError keeps
+        # its own error instead of being re-wrapped.
+        marker = argclass.ConfigurationError("custom parser error")
+
+        class FailingParser(argclass.INIDefaultsParser):
+            def parse(self):
+                # The constructor also instantiates this class for
+                # ``config_files`` (with no paths); only fail for the
+                # user-supplied file.
+                if self._paths:
+                    raise marker
+                return super().parse()
+
+        config = tmp_path / "app.ini"
+        config.write_text("[DEFAULT]\n")
+        cli = make_cli()(
+            config_argument="--config",
+            config_parser_class=FailingParser,
+        )
+        with pytest.raises(argclass.ConfigurationError) as exc_info:
+            cli.parse_args(["--config", str(config)])
+        assert exc_info.value is marker
+
+    def test_flag_without_value_reported_by_real_parser(self, capsys):
+        # The pre-scan swallows the syntax error; the real parser
+        # reports it with proper usage text and exits.
+        cli = make_cli()(config_argument="--config")
+        with pytest.raises(SystemExit):
+            cli.parse_args(["--config"])
+        assert "--config" in capsys.readouterr().err
+
+
+class TestConfigActionExplicitFileWins:
+    """An explicit --config passed to argclass.Config() must override
+    values coming from its search_paths (files merge in priority
+    order, later wins)."""
+
+    def test_explicit_overrides_search_paths(self, tmp_path):
+        preset = tmp_path / "preset.ini"
+        preset.write_text("[sec]\nkey = from-preset\nextra = e\n")
+        explicit = tmp_path / "explicit.ini"
+        explicit.write_text("[sec]\nkey = from-explicit\n")
+
+        class CLI(argclass.Parser):
+            config = argclass.Config(search_paths=[preset])
+
+        cli = CLI()
+        cli.parse_args(["--config", str(explicit)])
+        assert cli.config["sec"]["key"] == "from-explicit"
+        # Non-conflicting keys from search_paths are preserved.
+        assert cli.config["sec"]["extra"] == "e"


### PR DESCRIPTION
## Summary

`config_files=` lets the developer preset defaults from files chosen at
construction time. The new `Parser(config_argument="--config")` adds a CLI
flag so the **end user** can point at a config file whose values become
argument defaults, resolved at invocation time:

```python
class CLI(argclass.Parser):
    host: str = "localhost"
    port: int = 8080

parser = CLI(config_argument="--config")          # or ("-c", "--config", ...)
parser.parse_args(["--config", "prod.ini", "--port", "1234"])
# host comes from prod.ini, port from the CLI
```

Priority chain extends naturally:

```
declared defaults < config_files < config_argument file < env vars < CLI args
```

## Implementation

Two-pass parsing (the classic argparse chicken-and-egg: defaults must be known
before parsing, but the config path arrives as an argument):

1. A throwaway pre-scan parser — it neither prints nor exits — extracts only
   the config flag value from argv (syntax errors are left for the real parser
   to report with proper usage text).
2. The file is loaded through the shared `config_parser_class` machinery
   (INI/JSON/TOML or a custom `AbstractDefaultsParser`) and layered over the
   constructor config defaults.
3. The real parser is built as usual — required-relaxation, type-aware
   conversion, group/nested-group sections, and `--help` defaults all come
   from the existing defaults pipeline.

Details:

- An explicitly passed path that is missing or unparsable raises
  `ConfigurationError` — unlike `config_files`, which stays a lenient search
  list.
- The runtime defaults layer lives only for the duration of one
  `parse_args()` call (no staleness between parses).
- New `Parser.loaded_config_files` property reports applied files in priority
  order.
- No cascade into subparsers (consistent with `config_files`).

Also fixes a related pre-existing bug in `ConfigAction` (`argclass.Config()`):
an explicit `--config` file was merged **before** `search_paths`, so preset
files silently overrode the user's explicit choice. The explicit file now
wins.

## Tests & docs

- 19 new tests (`tests/test_config_argument.py`): the priority chain
  pair-by-pair, required-satisfied-by-config, nested group sections, JSON
  parser class, aliases/`=`-form, help output, error cases, re-parse
  isolation, and the `ConfigAction` ordering fix.
- Docs: new section in `config-files.md` (executable example), README example,
  `api.md` cross-references, `Parser.__init__` docstring (flows into the API
  reference via autodoc), feature bullet in `index.md`, pitfalls table row.

## Verification

- 725 tests green on Python 3.10–3.14; doc blocks executable and passing.
- ruff check/format clean; mypy clean (pre-existing `tomllib` baseline only);
  coverage at the 100% gate; Sphinx builds without warnings.